### PR TITLE
Fixed typo in applyForceToCenter

### DIFF
--- a/lib/src/dynamics/body.dart
+++ b/lib/src/dynamics/body.dart
@@ -444,8 +444,8 @@ class Body {
       setAwake(true);
     }
 
-    force.x += force.x;
-    force.y += force.y;
+    _force.x += force.x;
+    _force.y += force.y;
   }
 
   /**


### PR DESCRIPTION
The method updates the parameter value instead of the field.