### PR TITLE
Fix strong mode error in buffer_utils.sort

### DIFF
--- a/lib/src/buffer_utils.dart
+++ b/lib/src/buffer_utils.dart
@@ -145,8 +145,8 @@ void arraycopy(List src, int srcPos, List dest, int destPos, int length) {
 
 // Replace Java's Arrays::sort.
 // TODO(srdjan): Make a version that does not require copying.
-void sort(List<Comparable> list, int fromPos, int toPos) {
-  List<Comparable> temp = new List.from(list.getRange(fromPos, toPos));
+void sort<T>(List<T> list, int fromPos, int toPos) {
+  List<T> temp = new List.from(list.getRange(fromPos, toPos));
   temp.sort();
   list.setRange(fromPos, toPos, temp);
 }


### PR DESCRIPTION
Fix strong mode error in buffer_utils.sort. Once temp is made, the type information is lost and setRange fails type checks.

You can see this error by running

```bash
pub serve --web-compiler dartdevc example
```

and going to http://localhost:8080/?demo=box_test