### PR TITLE
Fixing doc comments to please pub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .packages
 .pub
 packages

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .pub
 packages
 pubspec.lock
+.dart_tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.4.5
+* Fixing warnings and formatting
+
+### 0.4.1 - 0.4.4
+* Updates related to Flame interop + bugfixes
+
 ### 0.4.0
 
 * Breaking: Made package strong-mode compliant 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,6 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+linter:
+  rules:
+    - slash_for_doc_comments

--- a/benchmark/bench2d.dart
+++ b/benchmark/bench2d.dart
@@ -22,7 +22,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 
 void main() {
   new Bench2d()

--- a/benchmark/bench2d.dart
+++ b/benchmark/bench2d.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 import 'package:box2d_flame/box2d.dart';
 

--- a/benchmark/bench2d_web.dart
+++ b/benchmark/bench2d_web.dart
@@ -24,7 +24,7 @@
 
 import 'dart:html';
 
-import 'package:box2d/box2d_browser.dart';
+import 'package:box2d_flame/box2d_browser.dart';
 
 import 'bench2d.dart';
 

--- a/benchmark/bench2d_web.dart
+++ b/benchmark/bench2d_web.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 import 'dart:html';
 
@@ -45,10 +45,8 @@ class Bench2dWeb extends Bench2d {
   ViewportTransform viewport;
   DebugDraw debugDraw;
 
-  /**
-   * Creates the canvas and readies the demo for animation. Must be called
-   * before calling runAnimation.
-   */
+  /// Creates the canvas and readies the demo for animation. Must be called
+  /// before calling runAnimation.
   void initializeAnimation() {
     // Setup the canvas.
     canvas = new CanvasElement()

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -14,7 +14,6 @@
         console.log('Browser does not support Dart. Expect JS fallback.');
       }
     </script>
-    <script type="application/dart" src="bench2d_web.dart"></script>
-    <script src="packages/browser/dart.js"></script>
+    <script defer src="bench2d_web.dart.js"></script>
   </body>
 </html>

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,3 @@
+*.js
+*.js.deps
+*.js.map

--- a/example/ball_cage.dart
+++ b/example/ball_cage.dart
@@ -24,7 +24,7 @@
 
 library BallCage;
 
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 
 import 'demo.dart';
 

--- a/example/ball_cage.dart
+++ b/example/ball_cage.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library BallCage;
 
@@ -29,20 +29,20 @@ import 'package:box2d_flame/box2d.dart';
 import 'demo.dart';
 
 class BallCage extends Demo {
-  /** Starting position of ball cage in the world. */
+  /// Starting position of ball cage in the world.
   static const double START_X = -20.0;
   static const double START_Y = -20.0;
 
-  /** The radius of the balls forming the arena. */
+  /// The radius of the balls forming the arena.
   static const double WALL_BALL_RADIUS = 2.0;
 
-  /** Radius of the active ball. */
+  /// Radius of the active ball.
   static const double ACTIVE_BALL_RADIUS = 1.0;
 
-  /** Constructs a new BallCage. */
+  /// Constructs a new BallCage.
   BallCage() : super("Ball cage");
 
-  /** Entrypoint. */
+  /// Entrypoint.
   static void main() {
     final cage = new BallCage();
     cage.initialize();

--- a/example/blob_test.dart
+++ b/example/blob_test.dart
@@ -69,7 +69,7 @@ class BlobTest extends Demo {
     double bodyRadius = 0.5;
     for (int i = 0; i < nBodies; ++i) {
       double angle = MathUtils.translateAndScale(
-          i.toDouble(), 0.0, nBodies, 0.0, Math.PI * 2);
+          i.toDouble(), 0.0, nBodies, 0.0, Math.pi * 2);
       BodyDef bd = new BodyDef();
       bd.fixedRotation = true;
 

--- a/example/blob_test.dart
+++ b/example/blob_test.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library BlobTest;
 
@@ -30,10 +30,10 @@ import 'package:box2d_flame/src/math_utils.dart' as MathUtils;
 import 'demo.dart';
 
 class BlobTest extends Demo {
-  /** Constructs a new BlobTest. */
+  /// Constructs a new BlobTest.
   BlobTest() : super("Blob test");
 
-  /** Entrypoint. */
+  /// Entrypoint.
   static void main() {
     final blob = new BlobTest();
     blob.initialize();

--- a/example/blob_test.dart
+++ b/example/blob_test.dart
@@ -25,8 +25,8 @@
 library BlobTest;
 
 import 'dart:math' as Math;
-import 'package:box2d/box2d.dart';
-import 'package:box2d/src/math_utils.dart' as MathUtils;
+import 'package:box2d_flame/box2d.dart';
+import 'package:box2d_flame/src/math_utils.dart' as MathUtils;
 import 'demo.dart';
 
 class BlobTest extends Demo {

--- a/example/box_test.dart
+++ b/example/box_test.dart
@@ -25,7 +25,7 @@
 library BoxTest;
 
 import 'dart:math' as Math;
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 import 'demo.dart';
 
 class BoxTest extends Demo {

--- a/example/box_test.dart
+++ b/example/box_test.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library BoxTest;
 
@@ -29,10 +29,10 @@ import 'package:box2d_flame/box2d.dart';
 import 'demo.dart';
 
 class BoxTest extends Demo {
-  /** Constructs a new BoxTest. */
+  /// Constructs a new BoxTest.
   BoxTest() : super("Box test");
 
-  /** Entrypoint. */
+  /// Entrypoint.
   static void main() {
     final boxTest = new BoxTest();
     boxTest.initialize();

--- a/example/box_test.dart
+++ b/example/box_test.dart
@@ -72,7 +72,7 @@ class BoxTest extends Demo {
   void _createBox() {
     // Create shape
     final PolygonShape shape = new PolygonShape();
-    shape.setAsBox(3.0, 1.5, new Vector2.zero(), Math.PI / 2);
+    shape.setAsBox(3.0, 1.5, new Vector2.zero(), Math.pi / 2);
 
     // Define fixture (links body and shape)
     final FixtureDef activeFixtureDef = new FixtureDef();

--- a/example/circle_stress.dart
+++ b/example/circle_stress.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library CircleStress;
 
@@ -28,20 +28,20 @@ import 'dart:math' as Math;
 import 'package:box2d_flame/box2d.dart';
 import 'demo.dart';
 
-/** Scale of the viewport for this Demo. */
+/// Scale of the viewport for this Demo.
 const double _MY_VIEWPORT_SCALE = 4.0;
 
 class CircleStress extends Demo {
-  /** The number of columns of balls in the pen. */
+  /// The number of columns of balls in the pen.
   static const int COLUMNS = 8;
 
-  /** This number of balls will be created on each layer. */
+  /// This number of balls will be created on each layer.
   static const int LOAD_SIZE = 20;
 
-  /** Construct a new Circle Stress Demo. */
+  /// Construct a new Circle Stress Demo.
   CircleStress() : super("Circle stress");
 
-  /** Creates all bodies. */
+  /// Creates all bodies.
   void initialize() {
     {
       final bd = new BodyDef();

--- a/example/circle_stress.dart
+++ b/example/circle_stress.dart
@@ -82,12 +82,12 @@ class CircleStress extends Demo {
       // Corners
       final cornerDef = new BodyDef();
       sd.setAsBoxXY(20.0, 3.0);
-      cornerDef.angle = (-Math.PI / 4.0);
+      cornerDef.angle = (-Math.pi / 4.0);
       cornerDef.position = new Vector2(-35.0, 8.0);
       Body myBod = world.createBody(cornerDef);
       bodies.add(myBod);
       myBod.createFixtureFromShape(sd);
-      cornerDef.angle = (Math.PI / 4.0);
+      cornerDef.angle = (Math.pi / 4.0);
       cornerDef.position = new Vector2(35.0, 8.0);
       myBod = world.createBody(cornerDef);
       bodies.add(myBod);
@@ -117,9 +117,9 @@ class CircleStress extends Demo {
 
       for (int i = 0; i < numPieces; i++) {
         double xPos =
-            radius * Math.cos(2 * Math.PI * (i / numPieces.toDouble()));
+            radius * Math.cos(2 * Math.pi * (i / numPieces.toDouble()));
         double yPos =
-            radius * Math.sin(2 * Math.PI * (i / numPieces.toDouble()));
+            radius * Math.sin(2 * Math.pi * (i / numPieces.toDouble()));
 
         var cd = new CircleShape()
           ..radius = 1.2
@@ -142,7 +142,7 @@ class CircleStress extends Demo {
 
       RevoluteJointDef rjd = new RevoluteJointDef()
         ..initialize(body, groundBody, body.position)
-        ..motorSpeed = Math.PI
+        ..motorSpeed = Math.pi
         ..maxMotorTorque = 1000000.0
         ..enableMotor = true;
 

--- a/example/circle_stress.dart
+++ b/example/circle_stress.dart
@@ -25,7 +25,7 @@
 library CircleStress;
 
 import 'dart:math' as Math;
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 import 'demo.dart';
 
 /** Scale of the viewport for this Demo. */

--- a/example/compile.sh
+++ b/example/compile.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+shopt -s nullglob
+for f in *.dart; do
+  if [ "$f" == "demo.dart" ] ; then
+    continue;
+  fi
+  dart2js -o $f.js $f
+done

--- a/example/demo.dart
+++ b/example/demo.dart
@@ -26,7 +26,7 @@ library demo;
 
 import 'dart:async';
 import 'dart:html' hide Body;
-import 'package:box2d/box2d_browser.dart' hide Timer;
+import 'package:box2d_flame/box2d_browser.dart' hide Timer;
 
 /**
  * An abstract class for any Demo of the Box2D library.

--- a/example/demo.dart
+++ b/example/demo.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library demo;
 
@@ -28,32 +28,30 @@ import 'dart:async';
 import 'dart:html' hide Body;
 import 'package:box2d_flame/box2d_browser.dart' hide Timer;
 
-/**
- * An abstract class for any Demo of the Box2D library.
- */
+/// An abstract class for any Demo of the Box2D library.
 abstract class Demo {
   static const int WORLD_POOL_SIZE = 100;
   static const int WORLD_POOL_CONTAINER_SIZE = 10;
 
-  /** All of the bodies in a simulation. */
+  /// All of the bodies in a simulation.
   List<Body> bodies = new List<Body>();
 
-  /** The default canvas width and height. */
+  /// The default canvas width and height.
   static const int CANVAS_WIDTH = 900;
   static const int CANVAS_HEIGHT = 600;
 
-  /** Scale of the viewport. */
+  /// Scale of the viewport.
   static const double _VIEWPORT_SCALE = 10.0;
 
-  /** The gravity vector's y value. */
+  /// The gravity vector's y value.
   static const double GRAVITY = -10.0;
 
-  /** The timestep and iteration numbers. */
+  /// The timestep and iteration numbers.
   static const double TIME_STEP = 1 / 60;
   static const int VELOCITY_ITERATIONS = 10;
   static const int POSITION_ITERATIONS = 10;
 
-  /** The physics world. */
+  /// The physics world.
   final World world;
 
   // For timing the world.step call. It is kept running but reset and polled
@@ -62,28 +60,28 @@ abstract class Demo {
 
   final double _viewportScale;
 
-  /** The drawing canvas. */
+  /// The drawing canvas.
   CanvasElement canvas;
 
-  /** The canvas rendering context. */
+  /// The canvas rendering context.
   CanvasRenderingContext2D ctx;
 
-  /** The transform abstraction layer between the world and drawing canvas. */
+  /// The transform abstraction layer between the world and drawing canvas.
   ViewportTransform viewport;
 
-  /** The debug drawing tool. */
+  /// The debug drawing tool.
   DebugDraw debugDraw;
 
-  /** Frame count for fps */
+  /// Frame count for fps
   int frameCount;
 
-  /** HTML element used to display the FPS counter */
+  /// HTML element used to display the FPS counter
   Element fpsCounter;
 
-  /** Microseconds for world step update */
+  /// Microseconds for world step update
   int elapsedUs;
 
-  /** HTML element used to display the world step time */
+  /// HTML element used to display the world step time
   Element worldStepTime;
 
   Demo(String name, [Vector2 gravity, this._viewportScale = _VIEWPORT_SCALE])
@@ -94,7 +92,7 @@ abstract class Demo {
     querySelector("#title").innerHtml = name;
   }
 
-  /** Advances the world forward by timestep seconds. */
+  /// Advances the world forward by timestep seconds.
   void step(num timestamp) {
     _stopwatch.reset();
     world.stepDt(TIME_STEP, VELOCITY_ITERATIONS, POSITION_ITERATIONS);
@@ -108,10 +106,8 @@ abstract class Demo {
     window.requestAnimationFrame(step);
   }
 
-  /**
-   * Creates the canvas and readies the demo for animation. Must be called
-   * before calling runAnimation.
-   */
+  /// Creates the canvas and readies the demo for animation. Must be called
+  /// before calling runAnimation.
   void initializeAnimation() {
     // Setup the canvas.
     canvas = (new Element.tag('canvas') as CanvasElement)
@@ -146,9 +142,7 @@ abstract class Demo {
 
   void initialize();
 
-  /**
-   * Starts running the demo as an animation using an animation scheduler.
-   */
+  /// Starts running the demo as an animation using an animation scheduler.
   void runAnimation() {
     window.requestAnimationFrame(step);
   }

--- a/example/domino_test.dart
+++ b/example/domino_test.dart
@@ -24,7 +24,7 @@
 
 library DominoTest;
 
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 
 import 'demo.dart';
 

--- a/example/domino_test.dart
+++ b/example/domino_test.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library DominoTest;
 
@@ -28,7 +28,7 @@ import 'package:box2d_flame/box2d.dart';
 
 import 'demo.dart';
 
-/** Demonstration of dominoes being knocked over. */
+/// Demonstration of dominoes being knocked over.
 class DominoTest extends Demo {
   DominoTest() : super("Domino test");
 

--- a/example/domino_tower.dart
+++ b/example/domino_tower.dart
@@ -25,7 +25,7 @@
 library DominoTower;
 
 import 'dart:math' as Math;
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 
 import 'demo.dart';
 

--- a/example/domino_tower.dart
+++ b/example/domino_tower.dart
@@ -63,7 +63,7 @@ class DominoTower extends Demo {
     fd.friction = DOMINO_FRICTION;
     fd.restitution = 0.65;
     bd.position = new Vector2(x, y);
-    bd.angle = horizontal ? (Math.PI / 2.0) : 0.0;
+    bd.angle = horizontal ? (Math.pi / 2.0) : 0.0;
     Body myBody = world.createBody(bd);
     myBody.createFixtureFromFixtureDef(fd);
     bodies.add(myBody);

--- a/example/domino_tower.dart
+++ b/example/domino_tower.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library DominoTower;
 
@@ -35,16 +35,14 @@ class DominoTower extends Demo {
   static const double DOMINO_HEIGHT = 1.0;
   static const int BASE_COUNT = 25;
 
-  /**
-   * The density of the dominos under construction. Varies for different parts
-   * of the tower.
-   */
+  /// The density of the dominos under construction. Varies for different parts
+  /// of the tower.
   double dominoDensity;
 
-  /** Construct a new DominoTower. */
+  /// Construct a new DominoTower.
   DominoTower() : super("Domino tower");
 
-  /** Entrypoint. */
+  /// Entrypoint.
   static void main() {
     final tower = new DominoTower();
     tower.initialize();
@@ -69,9 +67,7 @@ class DominoTower extends Demo {
     bodies.add(myBody);
   }
 
-  /**
-   * Sets up the dominoes.
-   */
+  /// Sets up the dominoes.
   void initialize() {
     // Create the floor.
     {

--- a/example/friction_joint_test.dart
+++ b/example/friction_joint_test.dart
@@ -75,7 +75,7 @@ class FrictionJointTest extends Demo {
 
   void _createBoxShapeAndFixture() {
     final PolygonShape boxShape = new PolygonShape();
-    boxShape.setAsBox(3.0, 1.5, new Vector2.zero(), Math.PI / 2);
+    boxShape.setAsBox(3.0, 1.5, new Vector2.zero(), Math.pi / 2);
 
     // Define fixture (links body and shape)
     _boxFixture = new FixtureDef();

--- a/example/friction_joint_test.dart
+++ b/example/friction_joint_test.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library FrictionJointTest;
 
@@ -32,7 +32,7 @@ import 'demo.dart';
 class FrictionJointTest extends Demo {
   FrictionJointTest() : super("FrictionJoint test");
 
-  /** Entrypoint. */
+  /// Entrypoint.
   static void main() {
     final test = new FrictionJointTest();
     test.initialize();

--- a/example/friction_joint_test.dart
+++ b/example/friction_joint_test.dart
@@ -25,7 +25,7 @@
 library FrictionJointTest;
 
 import 'dart:math' as Math;
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 
 import 'demo.dart';
 

--- a/example/index.html
+++ b/example/index.html
@@ -67,8 +67,8 @@
         document.getElementById('fps').style.display = 'block';
         document.getElementById('world-step').style.display = 'block';
         var script = document.createElement('script');
-        script.setAttribute('type', 'application/dart');
-        script.setAttribute('src', demo + '.dart');
+        script.setAttribute('defer', '');
+        script.setAttribute('src', demo + '.dart.js');
         document.body.appendChild(script);
       } else {
         console.log('Creating menu');
@@ -87,7 +87,6 @@
         document.body.appendChild(menu);
       }
     </script>
-    <script src="packages/browser/dart.js"></script>
   </body>
 </html>
 

--- a/example/racer.dart
+++ b/example/racer.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library racer;
 

--- a/example/racer.dart
+++ b/example/racer.dart
@@ -26,8 +26,8 @@ library racer;
 
 import 'dart:html' hide Body;
 import 'dart:math';
-import 'package:box2d/box2d.dart';
-import 'package:box2d/src/math_utils.dart' as MathUtils;
+import 'package:box2d_flame/box2d.dart';
+import 'package:box2d_flame/src/math_utils.dart' as MathUtils;
 
 import 'demo.dart';
 

--- a/example/racer.dart
+++ b/example/racer.dart
@@ -81,7 +81,7 @@ class Racer extends Demo implements ContactListener {
   void preSolve(Contact contact, Manifold oldManifold) {}
   void postSolve(Contact contact, ContactImpulse impulse) {}
 
-  double radians(double deg) => deg * (PI / 180.0);
+  double radians(double deg) => deg * (pi / 180.0);
 
   void _createGround() {
     BodyDef def = new BodyDef();

--- a/example/racer/car.dart
+++ b/example/racer/car.dart
@@ -114,8 +114,8 @@ class Car {
   final double _backTireMaxLateralImpulse = 8.5;
   final double _frontTireMaxLateralImpulse = 7.5;
 
-  final double _lockAngle = (PI / 180) * 35;
-  final double _turnSpeedPerSec = (PI / 180) * 160;
+  final double _lockAngle = (pi / 180) * 35;
+  final double _turnSpeedPerSec = (pi / 180) * 160;
 
   Body _body;
   Tire _blTire, _brTire, _flTire, _frTire;

--- a/example/racer/control_state.dart
+++ b/example/racer/control_state.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** Used to track keyboard state. Entries are masked bitwise. */
+/// Used to track keyboard state. Entries are masked bitwise.
 
 part of racer;
 

--- a/lib/box2d.dart
+++ b/lib/box2d.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library box2d;
 

--- a/lib/box2d_browser.dart
+++ b/lib/box2d_browser.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015,  Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library box2d_browser;
 

--- a/lib/src/buffer_utils.dart
+++ b/lib/src/buffer_utils.dart
@@ -145,8 +145,8 @@ void arraycopy(List src, int srcPos, List dest, int destPos, int length) {
 
 // Replace Java's Arrays::sort.
 // TODO(srdjan): Make a version that does not require copying.
-void sort(List<Comparable> list, int fromPos, int toPos) {
-  List<Comparable> temp = new List.from(list.getRange(fromPos, toPos));
+void sort<T>(List<T> list, int fromPos, int toPos) {
+  List<T> temp = new List.from(list.getRange(fromPos, toPos));
   temp.sort();
   list.setRange(fromPos, toPos, temp);
 }

--- a/lib/src/buffer_utils.dart
+++ b/lib/src/buffer_utils.dart
@@ -1,32 +1,32 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library box2d.buffer_utils;
 
 import 'dart:typed_data';
 
-/** Reallocate a buffer. */
+/// Reallocate a buffer.
 List<T> reallocateBufferWithAlloc<T>(
     List oldBuffer, int oldCapacity, int newCapacity, T alloc()) {
   assert(newCapacity > oldCapacity);
@@ -44,7 +44,7 @@ List<T> reallocateBufferWithAlloc<T>(
   return newBuffer;
 }
 
-/** Reallocate a buffer. */
+/// Reallocate a buffer.
 List<int> reallocateBufferInt(
     List<int> oldBuffer, int oldCapacity, int newCapacity) {
   assert(newCapacity > oldCapacity);
@@ -58,7 +58,7 @@ List<int> reallocateBufferInt(
   return newBuffer;
 }
 
-/** Reallocate a buffer. */
+/// Reallocate a buffer.
 Float64List reallocateBuffer(
     Float64List oldBuffer, int oldCapacity, int newCapacity) {
   assert(newCapacity > oldCapacity);
@@ -69,10 +69,8 @@ Float64List reallocateBuffer(
   return newBuffer;
 }
 
-/**
-   * Reallocate a buffer. A 'deferred' buffer is reallocated only if it is not NULL. If
-   * 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
-   */
+/// Reallocate a buffer. A 'deferred' buffer is reallocated only if it is not NULL.
+/// If 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
 List<T> reallocateBufferWithAllocDeferred<T>(
     List<T> buffer,
     int userSuppliedCapacity,
@@ -88,10 +86,8 @@ List<T> reallocateBufferWithAllocDeferred<T>(
   return buffer;
 }
 
-/**
-   * Reallocate an int buffer. A 'deferred' buffer is reallocated only if it is not NULL. If
-   * 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
-   */
+/// Reallocate an int buffer. A 'deferred' buffer is reallocated only if it is not NULL.
+/// If 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
 List<int> reallocateBufferIntDeferred(List<int> buffer,
     int userSuppliedCapacity, int oldCapacity, int newCapacity, bool deferred) {
   assert(newCapacity > oldCapacity);
@@ -102,10 +98,8 @@ List<int> reallocateBufferIntDeferred(List<int> buffer,
   return buffer;
 }
 
-/**
-   * Reallocate a float buffer. A 'deferred' buffer is reallocated only if it is not NULL. If
-   * 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
-   */
+/// Reallocate a float buffer. A 'deferred' buffer is reallocated only if it is not NULL.
+/// If 'userSuppliedCapacity' is not zero, buffer is user supplied and must be kept.
 Float64List reallocateBufferFloat64Deferred(Float64List buffer,
     int userSuppliedCapacity, int oldCapacity, int newCapacity, bool deferred) {
   assert(newCapacity > oldCapacity);
@@ -116,7 +110,7 @@ Float64List reallocateBufferFloat64Deferred(Float64List buffer,
   return buffer;
 }
 
-/** Rotate an array, see std::rotate */
+/// Rotate an array, see std::rotate
 void rotate<T>(List<T> ray, int first, int new_first, int last) {
   int next = new_first;
   while (next != first) {
@@ -133,12 +127,10 @@ void rotate<T>(List<T> ray, int first, int new_first, int last) {
   }
 }
 
-/** Helper function to allocate a list of integers and set all elements to 0. */
+/// Helper function to allocate a list of integers and set all elements to 0.
 List<int> allocClearIntList(int size) => List<int>.filled(size, 0);
 
-/**
- * Helper function for ease of porting Java to Dart.
- */
+/// Helper function for ease of porting Java to Dart.
 void arraycopy(List src, int srcPos, List dest, int destPos, int length) {
   dest.setRange(destPos, length + destPos, src, srcPos);
 }

--- a/lib/src/buffer_utils.dart
+++ b/lib/src/buffer_utils.dart
@@ -30,7 +30,7 @@ import 'dart:typed_data';
 List<T> reallocateBufferWithAlloc<T>(
     List oldBuffer, int oldCapacity, int newCapacity, T alloc()) {
   assert(newCapacity > oldCapacity);
-  List<T> newBuffer = new List<T>(newCapacity);
+  List<T> newBuffer = List<T>(newCapacity);
   if (oldBuffer != null) {
     arraycopy(oldBuffer, 0, newBuffer, 0, oldCapacity);
   }
@@ -48,7 +48,7 @@ List<T> reallocateBufferWithAlloc<T>(
 List<int> reallocateBufferInt(
     List<int> oldBuffer, int oldCapacity, int newCapacity) {
   assert(newCapacity > oldCapacity);
-  List<int> newBuffer = new List<int>(newCapacity);
+  List<int> newBuffer = List<int>(newCapacity);
   if (oldBuffer != null) {
     arraycopy(oldBuffer, 0, newBuffer, 0, oldCapacity);
   }
@@ -62,7 +62,7 @@ List<int> reallocateBufferInt(
 Float64List reallocateBuffer(
     Float64List oldBuffer, int oldCapacity, int newCapacity) {
   assert(newCapacity > oldCapacity);
-  Float64List newBuffer = new Float64List(newCapacity);
+  Float64List newBuffer = Float64List(newCapacity);
   if (oldBuffer != null) {
     arraycopy(oldBuffer, 0, newBuffer, 0, oldCapacity);
   }
@@ -134,7 +134,7 @@ void rotate<T>(List<T> ray, int first, int new_first, int last) {
 }
 
 /** Helper function to allocate a list of integers and set all elements to 0. */
-List<int> allocClearIntList(int size) => new List<int>.filled(size, 0);
+List<int> allocClearIntList(int size) => List<int>.filled(size, 0);
 
 /**
  * Helper function for ease of porting Java to Dart.
@@ -146,7 +146,7 @@ void arraycopy(List src, int srcPos, List dest, int destPos, int length) {
 // Replace Java's Arrays::sort.
 // TODO(srdjan): Make a version that does not require copying.
 void sort<T>(List<T> list, int fromPos, int toPos) {
-  List<T> temp = new List.from(list.getRange(fromPos, toPos));
+  List<T> temp = List.from(list.getRange(fromPos, toPos));
   temp.sort();
   list.setRange(fromPos, toPos, temp);
 }

--- a/lib/src/callbacks/canvas_draw.dart
+++ b/lib/src/callbacks/canvas_draw.dart
@@ -26,8 +26,8 @@ library box2d.callbacks.canvas_draw;
 
 import 'dart:html';
 
-import 'package:box2d/box2d.dart';
-import 'package:box2d/src/math_utils.dart' as MathUtils;
+import 'package:box2d_flame/box2d.dart';
+import 'package:box2d_flame/src/math_utils.dart' as MathUtils;
 
 class CanvasDraw extends DebugDraw {
   /** The canvas rendering context with which to draw. */

--- a/lib/src/callbacks/canvas_draw.dart
+++ b/lib/src/callbacks/canvas_draw.dart
@@ -62,7 +62,7 @@ class CanvasDraw extends DebugDraw {
     // TODO(gregbglw): Do a single ctx transform rather than convert all of
     // these vectors.
     for (int i = 0; i < vertexCount; ++i) {
-      getWorldToScreenToOut(vertices[i], vertices[i]);
+      vertices[i] = getWorldToScreenToOut(vertices[i]);
     }
 
     ctx.beginPath();
@@ -83,8 +83,8 @@ class CanvasDraw extends DebugDraw {
   /** Draw a line segment. WARNING: This mutates [p1] and [p2]. */
   void drawSegment(Vector2 p1, Vector2 p2, Color3i color) {
     _setColor(color);
-    getWorldToScreenToOut(p1, p1);
-    getWorldToScreenToOut(p2, p2);
+    p1 = getWorldToScreenToOut(p1);
+    p2 = getWorldToScreenToOut(p2);
 
     ctx.beginPath();
     ctx.moveTo(p1.x, p1.y);
@@ -118,7 +118,7 @@ class CanvasDraw extends DebugDraw {
 
   void _pathCircle(Vector2 center, num radius, Color3i color) {
     _setColor(color);
-    getWorldToScreenToOut(center, center);
+    center = getWorldToScreenToOut(center);
 
     ctx.beginPath();
     ctx.arc(center.x, center.y, radius, 0, MathUtils.TWOPI, true);

--- a/lib/src/callbacks/canvas_draw.dart
+++ b/lib/src/callbacks/canvas_draw.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library box2d.callbacks.canvas_draw;
 
@@ -30,26 +30,22 @@ import 'package:box2d_flame/box2d.dart';
 import 'package:box2d_flame/src/math_utils.dart' as MathUtils;
 
 class CanvasDraw extends DebugDraw {
-  /** The canvas rendering context with which to draw. */
+  /// The canvas rendering context with which to draw.
   final CanvasRenderingContext2D ctx;
 
   CanvasDraw(ViewportTransform viewport, this.ctx) : super(viewport) {
     assert(null != viewport && null != ctx);
   }
 
-  /**
-   * Draw a closed polygon provided in CCW order. WARNING: This mutates
-   * [vertices].
-   */
+  /// Draw a closed polygon provided in CCW order. WARNING: This mutates
+  /// [vertices].
   void drawPolygon(List<Vector2> vertices, int vertexCount, Color3i color) {
     _pathPolygon(vertices, vertexCount, color);
     ctx.stroke();
   }
 
-  /**
-   * Draw a solid closed polygon provided in CCW order. WARNING: This mutates
-   * [vertices].
-   */
+  /// Draw a solid closed polygon provided in CCW order. WARNING: This mutates
+  /// [vertices].
   void drawSolidPolygon(
       List<Vector2> vertices, int vertexCount, Color3i color) {
     _pathPolygon(vertices, vertexCount, color);
@@ -80,7 +76,7 @@ class CanvasDraw extends DebugDraw {
     ctx.closePath();
   }
 
-  /** Draw a line segment. WARNING: This mutates [p1] and [p2]. */
+  /// Draw a line segment. WARNING: This mutates [p1] and [p2].
   void drawSegment(Vector2 p1, Vector2 p2, Color3i color) {
     _setColor(color);
     p1 = getWorldToScreenToOut(p1);
@@ -93,24 +89,22 @@ class CanvasDraw extends DebugDraw {
     ctx.stroke();
   }
 
-  /** Draw a circle. WARNING: This mutates [center]. */
+  /// Draw a circle. WARNING: This mutates [center].
   void drawCircle(Vector2 center, num radius, Color3i color, [Vector2 axis]) {
     radius *= viewportTransform.scale;
     _pathCircle(center, radius, color);
     ctx.stroke();
   }
 
-  /** Draw a solid circle. WARNING: This mutates [center]. */
+  /// Draw a solid circle. WARNING: This mutates [center].
   void drawSolidCircle(
       Vector2 center, num radius, Vector2 axis, Color3i color) {
     radius *= viewportTransform.scale;
     drawPoint(center, radius, color);
   }
 
-  /**
-   * Draws the given point with the given *unscaled* radius, in the given [color].
-   * WARNING: This mutates [point].
-   */
+  /// Draws the given point with the given *unscaled* radius, in the given [color].
+  /// WARNING: This mutates [point].
   void drawPoint(Vector2 point, num radiusOnScreen, Color3i color) {
     _pathCircle(point, radiusOnScreen, color);
     ctx.fill();
@@ -125,22 +119,20 @@ class CanvasDraw extends DebugDraw {
     ctx.closePath();
   }
 
-  /**
-   * Draw a transform. Choose your own length scale. WARNING: This mutates
-   * [xf.position].
-   */
+  /// Draw a transform. Choose your own length scale. WARNING: This mutates
+  /// [xf.position].
   void drawTransform(Transform xf, Color3i color) {
     drawCircle(xf.p, 0.1, color);
     // TODO(rupertk): Draw rotation representation (drawCircle axis parameter?)
   }
 
-  /** Draw a string. */
+  /// Draw a string.
   void drawStringXY(num x, num y, String s, Color3i color) {
     _setColor(color);
     ctx.strokeText(s, x, y);
   }
 
-  /** Sets the rendering context stroke and fill color to [color]. */
+  /// Sets the rendering context stroke and fill color to [color].
   void _setColor(Color3i color) {
     ctx.setStrokeColorRgb(color.x, color.y, color.z, 0.9);
     ctx.setFillColorRgb(color.x, color.y, color.z, 0.8);

--- a/lib/src/callbacks/contact_filter.dart
+++ b/lib/src/callbacks/contact_filter.dart
@@ -24,18 +24,11 @@
 
 part of box2d;
 
-/**
- * Implement this class to provide collision filtering. In other words, you can implement
- * this class if you want finer control over contact creation.
- */
+/// Implement this class to provide collision filtering. In other words, you can implement
+/// this class if you want finer control over contact creation.
 class ContactFilter {
-  /**
-   * Return true if contact calculations should be performed between these two shapes.
-   * @warning for performance reasons this is only called when the AABBs begin to overlap.
-   * @param fixtureA
-   * @param fixtureB
-   * @return
-   */
+  /// Return true if contact calculations should be performed between these two shapes.
+  /// @warning for performance reasons this is only called when the AABBs begin to overlap.
   bool shouldCollide(Fixture fixtureA, Fixture fixtureB) {
     Filter filterA = fixtureA.getFilterData();
     Filter filterB = fixtureB.getFilterData();

--- a/lib/src/callbacks/contact_impulse.dart
+++ b/lib/src/callbacks/contact_impulse.dart
@@ -24,11 +24,9 @@
 
 part of box2d;
 
-/**
- * Contact impulses for reporting. Impulses are used instead of forces because sub-step forces may
- * approach infinity for rigid body collisions. These match up one-to-one with the contact points in
- * b2Manifold.
- */
+/// Contact impulses for reporting. Impulses are used instead of forces because sub-step forces may
+/// approach infinity for rigid body collisions. These match up one-to-one with the contact points in
+/// b2Manifold.
 class ContactImpulse {
   Float64List normalImpulses = new Float64List(Settings.maxManifoldPoints);
   Float64List tangentImpulses = new Float64List(Settings.maxManifoldPoints);

--- a/lib/src/callbacks/contact_listener.dart
+++ b/lib/src/callbacks/contact_listener.dart
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2015, Daniel Murphy, Google
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *  * Redistributions of source code must retain the above copyright notice,
@@ -9,7 +9,7 @@
  *  * Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -24,59 +24,43 @@
 
 part of box2d;
 
-/**
- * Implement this class to get contact information. You can use these results for
- * things like sounds and game logic. You can also get contact results by
- * traversing the contact lists after the time step. However, you might miss
- * some contacts because continuous physics leads to sub-stepping.
- * Additionally you may receive multiple callbacks for the same contact in a
- * single time step.
- * You should strive to make your callbacks efficient because there may be
- * many callbacks per time step.
- * @warning You cannot create/destroy Box2D entities inside these callbacks.
- *
- */
+/// Implement this class to get contact information. You can use these results for
+/// things like sounds and game logic. You can also get contact results by
+/// traversing the contact lists after the time step. However, you might miss
+/// some contacts because continuous physics leads to sub-stepping.
+/// Additionally you may receive multiple callbacks for the same contact in a
+/// single time step.
+/// You should strive to make your callbacks efficient because there may be
+/// many callbacks per time step.
+/// @warning You cannot create/destroy Box2D entities inside these callbacks.
 abstract class ContactListener {
-  /**
-   * Called when two fixtures begin to touch.
-   * @param contact
-   */
+  /// Called when two fixtures begin to touch.
   void beginContact(Contact contact);
 
-  /**
-   * Called when two fixtures cease to touch.
-   * @param contact
-   */
+  /// Called when two fixtures cease to touch.
   void endContact(Contact contact);
 
-  /**
-   * This is called after a contact is updated. This allows you to inspect a
-   * contact before it goes to the solver. If you are careful, you can modify the
-   * contact manifold (e.g. disable contact).
-   * A copy of the old manifold is provided so that you can detect changes.
-   * Note: this is called only for awake bodies.
-   * Note: this is called even when the number of contact points is zero.
-   * Note: this is not called for sensors.
-   * Note: if you set the number of contact points to zero, you will not
-   * get an EndContact callback. However, you may get a BeginContact callback
-   * the next step.
-   * Note: the oldManifold parameter is pooled, so it will be the same object for every callback
-   * for each thread.
-   * @param contact
-   * @param oldManifold
-   */
+  /// This is called after a contact is updated. This allows you to inspect a
+  /// contact before it goes to the solver. If you are careful, you can modify the
+  /// contact manifold (e.g. disable contact).
+  /// A copy of the old manifold is provided so that you can detect changes.
+  /// Note: this is called only for awake bodies.
+  /// Note: this is called even when the number of contact points is zero.
+  /// Note: this is not called for sensors.
+  /// Note: if you set the number of contact points to zero, you will not
+  /// get an EndContact callback. However, you may get a BeginContact callback
+  /// the next step.
+  /// Note: the oldManifold parameter is pooled, so it will be the same object for every callback
+  /// for each thread.
   void preSolve(Contact contact, Manifold oldManifold);
 
-  /**
-   * This lets you inspect a contact after the solver is finished. This is useful
-   * for inspecting impulses.
-   * Note: the contact manifold does not include time of impact impulses, which can be
-   * arbitrarily large if the sub-step is small. Hence the impulse is provided explicitly
-   * in a separate data structure.
-   * Note: this is only called for contacts that are touching, solid, and awake.
-   * @param contact
-   * @param impulse this is usually a pooled variable, so it will be modified after
-   * this call
-   */
+  /// This lets you inspect a contact after the solver is finished. This is useful
+  /// for inspecting impulses.
+  /// Note: the contact manifold does not include time of impact impulses, which can be
+  /// arbitrarily large if the sub-step is small. Hence the impulse is provided explicitly
+  /// in a separate data structure.
+  /// Note: this is only called for contacts that are touching, solid, and awake.
+  /// @param contact
+  /// @param impulse this is usually a pooled variable, so it will be modified after this call
   void postSolve(Contact contact, ContactImpulse impulse);
 }

--- a/lib/src/callbacks/debug_draw.dart
+++ b/lib/src/callbacks/debug_draw.dart
@@ -1,49 +1,51 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * Implement this abstract class to allow DBox2d to automatically draw your physics for debugging
- * purposes. Not intended to replace your own custom rendering routines!
- *
- * @author Daniel Murphy
- */
+/// Implement this abstract class to allow DBox2d to automatically draw your physics for debugging
+/// purposes. Not intended to replace your own custom rendering routines!
 abstract class DebugDraw {
-  /** Draw shapes */
+  /// Draw shapes
   static const int SHAPE_BIT = 1 << 1;
-  /** Draw joint connections */
+
+  /// Draw joint connections
   static const int JOINT_BIT = 1 << 2;
-  /** Draw axis aligned bounding boxes */
+
+  /// Draw axis aligned bounding boxes
   static const int AABB_BIT = 1 << 3;
-  /** Draw pairs of connected objects */
+
+  /// Draw pairs of connected objects
   static const int PAIR_BIT = 1 << 4;
-  /** Draw center of mass frame */
+
+  /// Draw center of mass frame
   static const int CENTER_OF_MASS_BIT = 1 << 5;
-  /** Draw dynamic tree */
+
+  /// Draw dynamic tree
   static const int DYNAMIC_TREE_BIT = 1 << 6;
-  /** Draw only the wireframe for drawing performance */
+
+  /// Draw only the wireframe for drawing performance
   static const int WIREFRAME_DRAWING_BIT = 1 << 7;
 
   int drawFlags = SHAPE_BIT;
@@ -64,14 +66,8 @@ abstract class DebugDraw {
     drawFlags &= ~flags;
   }
 
-  /**
-   * Draw a closed polygon provided in CCW order. This implementation uses
-   * {@link #drawSegment(Vec2, Vec2, Color3f)} to draw each side of the polygon.
-   *
-   * @param vertices
-   * @param vertexCount
-   * @param color
-   */
+  /// Draw a closed polygon provided in CCW order. This implementation uses
+  /// {@link #drawSegment(Vec2, Vec2, Color3f)} to draw each side of the polygon.
   void drawPolygon(List<Vector2> vertices, int vertexCount, Color3i color) {
     if (vertexCount == 1) {
       drawSegment(vertices[0], vertices[0], color);
@@ -89,84 +85,42 @@ abstract class DebugDraw {
 
   void drawPoint(Vector2 argPoint, double argRadiusOnScreen, Color3i argColor);
 
-  /**
-   * Draw a solid closed polygon provided in CCW order.
-   *
-   * @param vertices
-   * @param vertexCount
-   * @param color
-   */
+  /// Draw a solid closed polygon provided in CCW order.
   void drawSolidPolygon(List<Vector2> vertices, int vertexCount, Color3i color);
 
-  /**
-   * Draw a circle.
-   *
-   * @param center
-   * @param radius
-   * @param color
-   */
+  /// Draw a circle.
   void drawCircle(Vector2 center, double radius, Color3i color);
 
-  /** Draws a circle with an axis */
+  /// Draws a circle with an axis
   void drawCircleAxis(
       Vector2 center, double radius, Vector2 axis, Color3i color) {
     drawCircle(center, radius, color);
   }
 
-  /**
-   * Draw a solid circle.
-   *
-   * @param center
-   * @param radius
-   * @param axis
-   * @param color
-   */
+  /// Draw a solid circle.
   void drawSolidCircle(
       Vector2 center, double radius, Vector2 axis, Color3i color);
 
-  /**
-   * Draw a line segment.
-   *
-   * @param p1
-   * @param p2
-   * @param color
-   */
+  /// Draw a line segment.
   void drawSegment(Vector2 p1, Vector2 p2, Color3i color);
 
-  /**
-   * Draw a transform. Choose your own length scale
-   *
-   * @param xf
-   */
+  /// Draw a transform. Choose your own length scale
   void drawTransform(Transform xf, Color3i color);
 
-  /**
-   * Draw a string.
-   *
-   * @param x
-   * @param y
-   * @param s
-   * @param color
-   */
+  /// Draw a string.
   void drawStringXY(double x, double y, String s, Color3i color);
 
-  /**
-   * Draw a particle array
-   *
-   * @param colors can be null
-   */
+  /// Draw a particle array
+  /// @param colors can be null
   void drawParticles(List<Vector2> centers, double radius,
       List<ParticleColor> colors, int count);
 
-  /**
-   * Draw a particle array
-   *
-   * @param colors can be null
-   */
+  /// Draw a particle array
+  /// @param colors can be null
   void drawParticlesWireframe(List<Vector2> centers, double radius,
       List<ParticleColor> colors, int count);
 
-  /** Called at the end of drawing a world */
+  /// Called at the end of drawing a world
   void flush() {}
 
   void drawString(Vector2 pos, String s, Color3i color) {
@@ -177,65 +131,34 @@ abstract class DebugDraw {
     return viewportTransform;
   }
 
-  /**
-   * @param x
-   * @param y
-   * @param scale
-   * @deprecated use the viewport transform in {@link #getViewportTranform()}
-   */
+  /// @deprecated use the viewport transform in {@link #getViewportTranform()}
   void setCamera(double x, double y, double scale) {
     viewportTransform.setCamera(x, y, scale);
   }
 
-  /**
-   * Takes the world coordinates and returns the corresponding screen
-   * coordinates
-   */
+  /// Takes the world coordinates and returns the corresponding screen
+  /// coordinates
   Vector2 getWorldToScreenToOut(Vector2 input) =>
       viewportTransform.getWorldToScreen(input);
 
-  /**
-   * Takes the world coordinates and returns the corresponding screen
-   * coordinates
-   *
-   * @param worldX
-   * @param worldY
-   */
+  /// Takes the world coordinates and returns the corresponding screen
+  /// coordinates
   Vector2 getWorldToScreenToOutXY(double worldX, double worldY) =>
       getWorldToScreenToOut(Vector2(worldX, worldY));
 
-  /**
-   * Takes the world coordinate and returns the screen coordinates.
-   *
-   * @param argWorld
-   */
+  /// Takes the world coordinate and returns the screen coordinates.
   Vector2 getWorldToScreen(Vector2 argWorld) =>
       viewportTransform.getWorldToScreen(argWorld);
 
-  /**
-   * Takes the world coordinates and returns the screen coordinates
-   *
-   * @param worldX
-   * @param worldY
-   */
+  /// Takes the world coordinates and returns the screen coordinates
   Vector2 getWorldToScreenXY(double worldX, double worldY) =>
       viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
 
-  /**
-   * takes the screen coordinates (argScreen) and returns the world coordinates
-   *
-   * @param argScreen
-   */
+  /// Takes the screen coordinates (argScreen) and returns the world coordinates
   Vector2 getScreenToWorld(Vector2 argScreen) =>
       viewportTransform.getScreenToWorld(argScreen);
 
-  /**
-   * Takes the screen coordinates and returns the corresponding world
-   * coordinates
-   *
-   * @param screenX
-   * @param screenY
-   */
+  /// Takes the screen coordinates and returns the corresponding world coordinates
   Vector2 getScreenToWorldToOutXY(double screenX, double screenY) =>
       viewportTransform.getScreenToWorld(Vector2(screenX, screenY));
 }

--- a/lib/src/callbacks/debug_draw.dart
+++ b/lib/src/callbacks/debug_draw.dart
@@ -190,12 +190,19 @@ abstract class DebugDraw {
   /**
    * Takes the world coordinates and returns the corresponding screen
    * coordinates
+   */
+  Vector2 getWorldToScreenToOut(Vector2 input) =>
+      viewportTransform.getWorldToScreen(input);
+
+  /**
+   * Takes the world coordinates and returns the corresponding screen
+   * coordinates
    *
    * @param worldX
    * @param worldY
    */
   Vector2 getWorldToScreenToOutXY(double worldX, double worldY) =>
-      viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
+      getWorldToScreenToOut(Vector2(worldX, worldY));
 
   /**
    * Takes the world coordinate and returns the screen coordinates.

--- a/lib/src/callbacks/debug_draw.dart
+++ b/lib/src/callbacks/debug_draw.dart
@@ -195,7 +195,7 @@ abstract class DebugDraw {
    * @param worldY
    */
   Vector2 getWorldToScreenToOutXY(double worldX, double worldY) =>
-    viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
+      viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
 
   /**
    * Takes the world coordinate and returns the screen coordinates.

--- a/lib/src/callbacks/debug_draw.dart
+++ b/lib/src/callbacks/debug_draw.dart
@@ -188,90 +188,47 @@ abstract class DebugDraw {
   }
 
   /**
-   * @param argScreen
-   * @param argWorld
-   */
-  void getScreenToWorldToOut(Vector2 argScreen, Vector2 argWorld) {
-    viewportTransform.getScreenToWorld(argScreen, argWorld);
-  }
-
-  /**
-   * @param argWorld
-   * @param argScreen
-   */
-  void getWorldToScreenToOut(Vector2 argWorld, Vector2 argScreen) {
-    viewportTransform.getWorldToScreen(argWorld, argScreen);
-  }
-
-  /**
-   * Takes the world coordinates and puts the corresponding screen coordinates in argScreen.
-   *
-   * @param worldX
-   * @param worldY
-   * @param argScreen
-   */
-  void getWorldToScreenToOutXY(
-      double worldX, double worldY, Vector2 argScreen) {
-    argScreen.setValues(worldX, worldY);
-    viewportTransform.getWorldToScreen(argScreen, argScreen);
-  }
-
-  /**
-   * takes the world coordinate (argWorld) and returns the screen coordinates.
-   *
-   * @param argWorld
-   */
-  Vector2 getWorldToScreen(Vector2 argWorld) {
-    Vector2 screen = new Vector2.zero();
-    viewportTransform.getWorldToScreen(argWorld, screen);
-    return screen;
-  }
-
-  /**
-   * Takes the world coordinates and returns the screen coordinates.
+   * Takes the world coordinates and returns the corresponding screen
+   * coordinates
    *
    * @param worldX
    * @param worldY
    */
-  Vector2 getWorldToScreenXY(double worldX, double worldY) {
-    Vector2 argScreen = new Vector2(worldX, worldY);
-    viewportTransform.getWorldToScreen(argScreen, argScreen);
-    return argScreen;
-  }
+  Vector2 getWorldToScreenToOutXY(double worldX, double worldY) =>
+    viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
 
   /**
-   * takes the screen coordinates and puts the corresponding world coordinates in argWorld.
+   * Takes the world coordinate and returns the screen coordinates.
    *
-   * @param screenX
-   * @param screenY
    * @param argWorld
    */
-  void getScreenToWorldToOutXY(
-      double screenX, double screenY, Vector2 argWorld) {
-    argWorld.setValues(screenX, screenY);
-    viewportTransform.getScreenToWorld(argWorld, argWorld);
-  }
+  Vector2 getWorldToScreen(Vector2 argWorld) =>
+      viewportTransform.getWorldToScreen(argWorld);
+
+  /**
+   * Takes the world coordinates and returns the screen coordinates
+   *
+   * @param worldX
+   * @param worldY
+   */
+  Vector2 getWorldToScreenXY(double worldX, double worldY) =>
+      viewportTransform.getWorldToScreen(Vector2(worldX, worldY));
 
   /**
    * takes the screen coordinates (argScreen) and returns the world coordinates
    *
    * @param argScreen
    */
-  Vector2 getScreenToWorld(Vector2 argScreen) {
-    Vector2 world = new Vector2.zero();
-    viewportTransform.getScreenToWorld(argScreen, world);
-    return world;
-  }
+  Vector2 getScreenToWorld(Vector2 argScreen) =>
+      viewportTransform.getScreenToWorld(argScreen);
 
   /**
-   * takes the screen coordinates and returns the world coordinates.
+   * Takes the screen coordinates and returns the corresponding world
+   * coordinates
    *
    * @param screenX
    * @param screenY
    */
-  Vector2 getScreenToWorldXY(double screenX, double screenY) {
-    Vector2 screen = new Vector2(screenX, screenY);
-    viewportTransform.getScreenToWorld(screen, screen);
-    return screen;
-  }
+  Vector2 getScreenToWorldToOutXY(double screenX, double screenY) =>
+      viewportTransform.getScreenToWorld(Vector2(screenX, screenY));
 }

--- a/lib/src/callbacks/destruction_listener.dart
+++ b/lib/src/callbacks/destruction_listener.dart
@@ -24,23 +24,17 @@
 
 part of box2d;
 
-/**
- * Joints and fixtures are destroyed when their associated
- * body is destroyed. Implement this listener so that you
- * may nullify references to these joints and shapes.
- */
+/// Joints and fixtures are destroyed when their associated
+/// body is destroyed. Implement this listener so that you
+/// may nullify references to these joints and shapes.
 abstract class DestructionListener {
-  /**
-   * Called when any joint is about to be destroyed due
-   * to the destruction of one of its attached bodies.
-   * @param joint
-   */
+  /// Called when any joint is about to be destroyed due
+  /// to the destruction of one of its attached bodies.
+  /// @param joint
   void sayGoodbyeJoint(Joint joint);
 
-  /**
-   * Called when any fixture is about to be destroyed due
-   * to the destruction of its parent body.
-   * @param fixture
-   */
+  /// Called when any fixture is about to be destroyed due
+  /// to the destruction of its parent body.
+  /// @param fixture
   void sayGoodbyeFixture(Fixture fixture);
 }

--- a/lib/src/callbacks/particle_destruction_listener.dart
+++ b/lib/src/callbacks/particle_destruction_listener.dart
@@ -25,16 +25,10 @@
 part of box2d;
 
 abstract class ParticleDestructionListener {
-  /**
-   * Called when any particle group is about to be destroyed.
-   */
+  /// Called when any particle group is about to be destroyed.
   void sayGoodbyeParticleGroup(ParticleGroup group);
 
-  /**
-   * Called when a particle is about to be destroyed. The index can be used in conjunction with
-   * {@link World#getParticleUserDataBuffer} to determine which particle has been destroyed.
-   * 
-   * @param index
-   */
+  /// Called when a particle is about to be destroyed. The index can be used in conjunction with
+  /// {@link World#getParticleUserDataBuffer} to determine which particle has been destroyed.
   void sayGoodbyeIndex(int index);
 }

--- a/lib/src/callbacks/particle_query_callback.dart
+++ b/lib/src/callbacks/particle_query_callback.dart
@@ -24,15 +24,11 @@
 
 part of box2d;
 
-/**
- * Callback class for AABB queries. See
- * {@link World#queryAABB(QueryCallback, org.jbox2d.collision.AABB)}.
- */
+/// Callback class for AABB queries. See
+/// {@link World#queryAABB(QueryCallback, org.jbox2d.collision.AABB)}.
 abstract class ParticleQueryCallback {
-  /**
-   * Called for each particle found in the query AABB.
-   * 
-   * @return false to terminate the query.
-   */
+  /// Called for each particle found in the query AABB.
+  ///
+  /// @return false to terminate the query.
   bool reportParticle(int index);
 }

--- a/lib/src/callbacks/particle_raycast_callback.dart
+++ b/lib/src/callbacks/particle_raycast_callback.dart
@@ -25,17 +25,8 @@
 part of box2d;
 
 abstract class ParticleRaycastCallback {
-  /**
-   * Called for each particle found in the query. See
-   * {@link RayCastCallback#reportFixture(org.jbox2d.dynamics.Fixture, Vec2, Vec2, float)} for
-   * argument info.
-   * 
-   * @param index
-   * @param point
-   * @param normal
-   * @param fraction
-   * @return
-   */
+  /// Called for each particle found in the query. See
+  /// {@link RayCastCallback#reportFixture(org.jbox2d.dynamics.Fixture, Vec2, Vec2, float)} for argument info.
   double reportParticle(
       int index, Vector2 point, Vector2 normal, double fraction);
 }

--- a/lib/src/callbacks/query_callback.dart
+++ b/lib/src/callbacks/query_callback.dart
@@ -24,15 +24,11 @@
 
 part of box2d;
 
-/**
- * Callback class for AABB queries.
- * See {@link World#queryAABB(QueryCallback, org.jbox2d.collision.AABB)}.
- */
+/// Callback class for AABB queries.
+/// See {@link World#queryAABB(QueryCallback, org.jbox2d.collision.AABB)}.
 abstract class QueryCallback {
-  /**
-   * Called for each fixture found in the query AABB.
-   * @param fixture
-   * @return false to terminate the query.
-   */
+  /// Called for each fixture found in the query AABB.
+  /// @param fixture
+  /// @return false to terminate the query.
   bool reportFixture(Fixture fixture);
 }

--- a/lib/src/callbacks/raycast_callback.dart
+++ b/lib/src/callbacks/raycast_callback.dart
@@ -24,25 +24,20 @@
 
 part of box2d;
 
-/**
- * Callback class for ray casts.
- * See {@link World#raycast(RayCastCallback, Vec2, Vec2)}
- */
+/// Callback class for ray casts.
+/// See {@link World#raycast(RayCastCallback, Vec2, Vec2)}
 abstract class RayCastCallback {
-  /**
-   * Called for each fixture found in the query. You control how the ray cast
-   * proceeds by returning a float:
-   * return -1: ignore this fixture and continue
-   * return 0: terminate the ray cast
-   * return fraction: clip the ray to this point
-   * return 1: don't clip the ray and continue
-   * @param fixture the fixture hit by the ray
-   * @param point the point of initial intersection
-   * @param normal the normal vector at the point of intersection
-   * @return -1 to filter, 0 to terminate, fraction to clip the ray for
-   * closest hit, 1 to continue
-   * @param fraction
-   */
+  /// Called for each fixture found in the query. You control how the ray cast
+  /// proceeds by returning a float:
+  /// return -1: ignore this fixture and continue
+  /// return 0: terminate the ray cast
+  /// return fraction: clip the ray to this point
+  /// return 1: don't clip the ray and continue
+  /// @param fixture the fixture hit by the ray
+  /// @param point the point of initial intersection
+  /// @param normal the normal vector at the point of intersection
+  /// @param fraction
+  /// @return -1 to filter, 0 to terminate, fraction to clip the ray for closest hit, 1 to continue
   double reportFixture(
       Fixture fixture, Vector2 point, Vector2 normal, double fraction);
 }

--- a/lib/src/callbacks/tree_callback.dart
+++ b/lib/src/callbacks/tree_callback.dart
@@ -24,15 +24,10 @@
 
 part of box2d;
 
-/**
- * callback for {@link DynamicTree}
- *
- */
+/// Callback for {@link DynamicTree}
 abstract class TreeCallback {
-  /**
-   * Callback from a query request.  
-   * @param proxyId the id of the proxy
-   * @return if the query should be continued
-   */
+  /// Callback from a query request.
+  /// @param proxyId the id of the proxy
+  /// @return if the query should be continued
   bool treeCallback(int proxyId);
 }

--- a/lib/src/callbacks/tree_raycast_callback.dart
+++ b/lib/src/callbacks/tree_raycast_callback.dart
@@ -24,17 +24,8 @@
 
 part of box2d;
 
-/**
- * callback for {@link DynamicTree}
- * @author Daniel Murphy
- *
- */
+/// Callback for {@link DynamicTree}
 abstract class TreeRayCastCallback {
-  /**
-   * 
-   * @param input
-   * @param nodeId
-   * @return the fraction to the node
-   */
+  /// retruns the fraction to the node
   double raycastCallback(RayCastInput input, int nodeId);
 }

--- a/lib/src/collision/aabb.dart
+++ b/lib/src/collision/aabb.dart
@@ -212,8 +212,8 @@ class AABB {
    */
   bool raycastWithPool(final RayCastOutput output, final RayCastInput input,
       IWorldPool argPool) {
-    double tmin = -double.MAX_FINITE;
-    double tmax = double.MAX_FINITE;
+    double tmin = -double.maxFinite;
+    double tmax = double.maxFinite;
 
     final Vector2 p = argPool.popVec2();
     final Vector2 d = argPool.popVec2();

--- a/lib/src/collision/aabb.dart
+++ b/lib/src/collision/aabb.dart
@@ -35,8 +35,8 @@ class AABB {
    * Creates the default object, with vertices at 0,0 and 0,0.
    */
   AABB()
-      : lowerBound = new Vector2.zero(),
-        upperBound = new Vector2.zero();
+      : lowerBound = Vector2.zero(),
+        upperBound = Vector2.zero();
 
   /**
    * Copies from the given object
@@ -44,8 +44,8 @@ class AABB {
    * @param copy the object to copy from
    */
   AABB.copy(final AABB copy)
-      : lowerBound = new Vector2.copy(copy.lowerBound),
-        upperBound = new Vector2.copy(copy.upperBound);
+      : lowerBound = Vector2.copy(copy.lowerBound),
+        upperBound = Vector2.copy(copy.upperBound);
 
   /**
    * Creates an AABB object using the given bounding vertices.
@@ -54,8 +54,8 @@ class AABB {
    * @param maxVertex the top right vertex of the bounding box
    */
   AABB.withVec2(final Vector2 lowerVertex, final Vector2 upperVertex)
-      : lowerBound = new Vector2.copy(lowerVertex),
-        upperBound = new Vector2.copy(upperVertex);
+      : lowerBound = Vector2.copy(lowerVertex),
+        upperBound = Vector2.copy(upperVertex);
 
   /**
    * Sets this object from the given object
@@ -91,7 +91,7 @@ class AABB {
    * @return
    */
   Vector2 getCenter() {
-    final Vector2 center = new Vector2.copy(lowerBound);
+    final Vector2 center = Vector2.copy(lowerBound);
     center.add(upperBound);
     center.scale(.5);
     return center;
@@ -108,7 +108,7 @@ class AABB {
    * @return
    */
   Vector2 getExtents() {
-    final Vector2 center = new Vector2.copy(upperBound);
+    final Vector2 center = Vector2.copy(upperBound);
     center.sub(lowerBound);
     center.scale(.5);
     return center;
@@ -201,7 +201,7 @@ class AABB {
    * @return
    */
   bool raycast(final RayCastOutput output, final RayCastInput input) {
-    return raycastWithPool(output, input, new DefaultWorldPool(4, 4));
+    return raycastWithPool(output, input, DefaultWorldPool(4, 4));
   }
 
   /**

--- a/lib/src/collision/aabb.dart
+++ b/lib/src/collision/aabb.dart
@@ -1,67 +1,57 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/** An axis-aligned bounding box. */
+/// An axis-aligned bounding box.
 class AABB {
-  /** Bottom left vertex of bounding box. */
+  /// Bottom left vertex of bounding box.
   final Vector2 lowerBound;
-  /** Top right vertex of bounding box. */
+
+  /// Top right vertex of bounding box.
   final Vector2 upperBound;
 
-  /**
-   * Creates the default object, with vertices at 0,0 and 0,0.
-   */
+  /// Creates the default object, with vertices at 0,0 and 0,0.
   AABB()
       : lowerBound = Vector2.zero(),
         upperBound = Vector2.zero();
 
-  /**
-   * Copies from the given object
-   *
-   * @param copy the object to copy from
-   */
+  /// Copies from the given object
+  /// @param copy the object to copy from
   AABB.copy(final AABB copy)
       : lowerBound = Vector2.copy(copy.lowerBound),
         upperBound = Vector2.copy(copy.upperBound);
 
-  /**
-   * Creates an AABB object using the given bounding vertices.
-   *
-   * @param lowerVertex the bottom left vertex of the bounding box
-   * @param maxVertex the top right vertex of the bounding box
-   */
+  /// Creates an AABB object using the given bounding vertices.
+  /// @param lowerVertex the bottom left vertex of the bounding box
+  /// @param maxVertex the top right vertex of the bounding box
   AABB.withVec2(final Vector2 lowerVertex, final Vector2 upperVertex)
       : lowerBound = Vector2.copy(lowerVertex),
         upperBound = Vector2.copy(upperVertex);
 
-  /**
-   * Sets this object from the given object
-   *
-   * @param aabb the object to copy from
-   */
+  /// Sets this object from the given object
+  /// @param aabb the object to copy from
   void set(final AABB aabb) {
     Vector2 v = aabb.lowerBound;
     lowerBound.x = v.x;
@@ -71,7 +61,7 @@ class AABB {
     upperBound.y = v1.y;
   }
 
-  /** Verify that the bounds are sorted */
+  /// Verify that the bounds are sorted
   bool isValid() {
     final double dx = upperBound.x - lowerBound.x;
     if (dx < 0.0) {
@@ -85,11 +75,7 @@ class AABB {
         MathUtils.vector2IsValid(upperBound);
   }
 
-  /**
-   * Get the center of the AABB
-   *
-   * @return
-   */
+  /// Get the center of the AABB
   Vector2 getCenter() {
     final Vector2 center = Vector2.copy(lowerBound);
     center.add(upperBound);
@@ -102,11 +88,7 @@ class AABB {
     out.y = (lowerBound.y + upperBound.y) * .5;
   }
 
-  /**
-   * Get the extents of the AABB (half-widths).
-   *
-   * @return
-   */
+  /// Get the extents of the AABB (half-widths).
   Vector2 getExtents() {
     final Vector2 center = Vector2.copy(upperBound);
     center.sub(lowerBound);
@@ -128,12 +110,7 @@ class AABB {
     argRay[3].x -= upperBound.x - lowerBound.x;
   }
 
-  /**
-   * Combine two AABBs into this one.
-   *
-   * @param aabb1
-   * @param aab
-   */
+  /// Combine two AABBs into this one.
   void combine2(final AABB aabb1, final AABB aab) {
     lowerBound.x = aabb1.lowerBound.x < aab.lowerBound.x
         ? aabb1.lowerBound.x
@@ -149,20 +126,12 @@ class AABB {
         : aab.upperBound.y;
   }
 
-  /**
-   * Gets the perimeter length
-   *
-   * @return
-   */
+  /// Gets the perimeter length
   double getPerimeter() {
     return 2.0 * (upperBound.x - lowerBound.x + upperBound.y - lowerBound.y);
   }
 
-  /**
-   * Combines another aabb with this one
-   *
-   * @param aabb
-   */
+  /// Combines another aabb with this one
   void combine(final AABB aabb) {
     lowerBound.x =
         lowerBound.x < aabb.lowerBound.x ? lowerBound.x : aabb.lowerBound.x;
@@ -174,17 +143,8 @@ class AABB {
         upperBound.y > aabb.upperBound.y ? upperBound.y : aabb.upperBound.y;
   }
 
-  /**
-   * Does this aabb contain the provided AABB.
-   *
-   * @return
-   */
+  /// Does this aabb contain the provided AABB.
   bool contains(final AABB aabb) {
-    /*
-     * boolean result = true; result = result && lowerBound.x <= aabb.lowerBound.x; result = result
-     * && lowerBound.y <= aabb.lowerBound.y; result = result && aabb.upperBound.x <= upperBound.x;
-     * result = result && aabb.upperBound.y <= upperBound.y; return result;
-     */
     // djm: faster putting all of them together, as if one is false we leave the logic
     // early
     return lowerBound.x <= aabb.lowerBound.x &&
@@ -193,23 +153,12 @@ class AABB {
         aabb.upperBound.y <= upperBound.y;
   }
 
-  /**
-   * @deprecated please use {@link #raycast(RayCastOutput, RayCastInput, IWorldPool)} for better
-   *             performance
-   * @param output
-   * @param input
-   * @return
-   */
+  /// @deprecated please use {@link #raycast(RayCastOutput, RayCastInput, IWorldPool)} for better performance
   bool raycast(final RayCastOutput output, final RayCastInput input) {
     return raycastWithPool(output, input, DefaultWorldPool(4, 4));
   }
 
-  /**
-   * From Real-time Collision Detection, p179.
-   *
-   * @param output
-   * @param input
-   */
+  /// From Real-time Collision Detection, p179.
   bool raycastWithPool(final RayCastOutput output, final RayCastInput input,
       IWorldPool argPool) {
     double tmin = -double.maxFinite;

--- a/lib/src/collision/broadphase/broadphase.dart
+++ b/lib/src/collision/broadphase/broadphase.dart
@@ -27,26 +27,14 @@ part of box2d;
 abstract class BroadPhase {
   static const int NULL_PROXY = -1;
 
-  /**
-   * Create a proxy with an initial AABB. Pairs are not reported until updatePairs is called.
-   * 
-   * @param aabb
-   * @param userData
-   * @return
-   */
+  /// Create a proxy with an initial AABB. Pairs are not reported until updatePairs is called.
   int createProxy(AABB aabb, Object userData);
 
-  /**
-   * Destroy a proxy. It is up to the client to remove any pairs.
-   * 
-   * @param proxyId
-   */
+  /// Destroy a proxy. It is up to the client to remove any pairs.
   void destroyProxy(int proxyId);
 
-  /**
-   * Call MoveProxy as many times as you like, then when you are done call UpdatePairs to finalized
-   * the proxy pairs (for your time step).
-   */
+  /// Call MoveProxy as many times as you like, then when you are done call UpdatePairs to finalized
+  /// the proxy pairs (for your time step).
   void moveProxy(int proxyId, AABB aabb, Vector2 displacement);
 
   void touchProxy(int proxyId);
@@ -57,47 +45,28 @@ abstract class BroadPhase {
 
   bool testOverlap(int proxyIdA, int proxyIdB);
 
-  /**
-   * Get the number of proxies.
-   * 
-   * @return
-   */
+  /// Get the number of proxies.
   int getProxyCount();
 
   void drawTree(DebugDraw argDraw);
 
-  /**
-   * Update the pairs. This results in pair callbacks. This can only add pairs.
-   * 
-   * @param callback
-   */
+  /// Update the pairs. This results in pair callbacks. This can only add pairs.
   void updatePairs(PairCallback callback);
 
-  /**
-   * Query an AABB for overlapping proxies. The callback class is called for each proxy that
-   * overlaps the supplied AABB.
-   * 
-   * @param callback
-   * @param aabb
-   */
+  /// Query an AABB for overlapping proxies. The callback class is called for each proxy that
+  /// overlaps the supplied AABB.
   void query(TreeCallback callback, AABB aabb);
 
-  /**
-   * Ray-cast against the proxies in the tree. This relies on the callback to perform a exact
-   * ray-cast in the case were the proxy contains a shape. The callback also performs the any
-   * collision filtering. This has performance roughly equal to k * log(n), where k is the number of
-   * collisions and n is the number of proxies in the tree.
-   * 
-   * @param input the ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
-   * @param callback a callback class that is called for each proxy that is hit by the ray.
-   */
+  /// Ray-cast against the proxies in the tree. This relies on the callback to perform a exact
+  /// ray-cast in the case were the proxy contains a shape. The callback also performs the any
+  /// collision filtering. This has performance roughly equal to k * log(n), where k is the number of
+  /// collisions and n is the number of proxies in the tree.
+  ///
+  /// @param input the ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
+  /// @param callback a callback class that is called for each proxy that is hit by the ray.
   void raycast(TreeRayCastCallback callback, RayCastInput input);
 
-  /**
-   * Get the height of the embedded tree.
-   * 
-   * @return
-   */
+  /// Get the height of the embedded tree.
   int getTreeHeight();
 
   int getTreeBalance();

--- a/lib/src/collision/broadphase/broadphase_strategy.dart
+++ b/lib/src/collision/broadphase/broadphase_strategy.dart
@@ -25,79 +25,50 @@
 part of box2d;
 
 abstract class BroadPhaseStrategy {
-  /**
-   * Create a proxy. Provide a tight fitting AABB and a userData pointer.
-   * 
-   * @param aabb
-   * @param userData
-   * @return
-   */
+  /// Create a proxy. Provide a tight fitting AABB and a userData pointer.
   int createProxy(AABB aabb, Object userData);
 
-  /**
-   * Destroy a proxy
-   * 
-   * @param proxyId
-   */
+  /// Destroy a proxy
   void destroyProxy(int proxyId);
 
-  /**
-   * Move a proxy with a swepted AABB. If the proxy has moved outside of its fattened AABB, then the
-   * proxy is removed from the tree and re-inserted. Otherwise the function returns immediately.
-   * 
-   * @return true if the proxy was re-inserted.
-   */
+  /// Move a proxy with a swepted AABB. If the proxy has moved outside of its fattened AABB, then the
+  /// proxy is removed from the tree and re-inserted. Otherwise the function returns immediately.
+  /// @return true if the proxy was re-inserted.
   bool moveProxy(int proxyId, AABB aabb, Vector2 displacement);
 
   Object getUserData(int proxyId);
 
   AABB getFatAABB(int proxyId);
 
-  /**
-   * Query an AABB for overlapping proxies. The callback class is called for each proxy that
-   * overlaps the supplied AABB.
-   * 
-   * @param callback
-   * @param araabbgAABB
-   */
+  /// Query an AABB for overlapping proxies. The callback class is called for each proxy that
+  /// overlaps the supplied AABB.
+  ///
+  /// @param callback
+  /// @param araabbgAABB
   void query(TreeCallback callback, AABB aabb);
 
-  /**
-   * Ray-cast against the proxies in the tree. This relies on the callback to perform a exact
-   * ray-cast in the case were the proxy contains a shape. The callback also performs the any
-   * collision filtering. This has performance roughly equal to k * log(n), where k is the number of
-   * collisions and n is the number of proxies in the tree.
-   * 
-   * @param input the ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
-   * @param callback a callback class that is called for each proxy that is hit by the ray.
-   */
+  /// Ray-cast against the proxies in the tree. This relies on the callback to perform a exact
+  /// ray-cast in the case were the proxy contains a shape. The callback also performs the any
+  /// collision filtering. This has performance roughly equal to k * log(n), where k is the number of
+  /// collisions and n is the number of proxies in the tree.
+  ///
+  /// @param input the ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
+  /// @param callback a callback class that is called for each proxy that is hit by the ray.
   void raycast(TreeRayCastCallback callback, RayCastInput input);
 
-  /**
-   * Compute the height of the tree.
-   */
+  /// Compute the height of the tree.
   int computeHeight();
 
-  /**
-   * Compute the height of the binary tree in O(N) time. Should not be called often.
-   * 
-   * @return
-   */
+  /// Compute the height of the binary tree in O(N) time. Should not be called often.
+  ///
+  /// @return
   int getHeight();
 
-  /**
-   * Get the maximum balance of an node in the tree. The balance is the difference in height of the
-   * two children of a node.
-   * 
-   * @return
-   */
+  /// Get the maximum balance of an node in the tree. The balance is the difference in height of the
+  /// two children of a node.
   int getMaxBalance();
 
-  /**
-   * Get the ratio of the sum of the node areas to the root area.
-   * 
-   * @return
-   */
+  /// Get the ratio of the sum of the node areas to the root area.
   double getAreaRatio();
 
   void drawTree(DebugDraw draw);

--- a/lib/src/collision/broadphase/default_broadphase_buffer.dart
+++ b/lib/src/collision/broadphase/default_broadphase_buffer.dart
@@ -24,13 +24,9 @@
 
 part of box2d;
 
-/**
- * The broad-phase is used for computing pairs and performing volume queries and ray casts. This
- * broad-phase does not persist pairs. Instead, this reports potentially new pairs. It is up to the
- * client to consume the new pairs and to track subsequent overlap.
- * 
- * @author Daniel Murphy
- */
+/// The broad-phase is used for computing pairs and performing volume queries and ray casts. This
+/// broad-phase does not persist pairs. Instead, this reports potentially new pairs. It is up to the
+/// client to consume the new pairs and to track subsequent overlap.
 class DefaultBroadPhaseBuffer implements TreeCallback, BroadPhase {
   final BroadPhaseStrategy _tree;
 
@@ -202,9 +198,7 @@ class DefaultBroadPhaseBuffer implements TreeCallback, BroadPhase {
     }
   }
 
-  /**
-   * This is called from DynamicTree::query when we are gathering pairs.
-   */
+  /// This is called from DynamicTree::query when we are gathering pairs.
   bool treeCallback(int proxyId) {
     // A proxy cannot form a pair with itself.
     if (proxyId == _queryProxyId) {

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -398,7 +398,7 @@ class DynamicTree implements BroadPhaseStrategy {
 
     AABB b = new AABB();
     while (count > 1) {
-      double minCost = double.MAX_FINITE;
+      double minCost = double.maxFinite;
       int iMin = -1, jMin = -1;
       for (int i = 0; i < count; ++i) {
         AABB aabbi = _nodes[nodes[i]].aabb;

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -299,7 +299,7 @@ class DynamicTree implements BroadPhaseStrategy {
     }
     int height1 = _computeHeight(node.child1);
     int height2 = _computeHeight(node.child2);
-    return 1 + Math.max(height1, height2);
+    return 1 + Math.max<int>(height1, height2);
   }
 
   /**
@@ -423,7 +423,7 @@ class DynamicTree implements BroadPhaseStrategy {
       DynamicTreeNode parent = _allocateNode();
       parent.child1 = child1;
       parent.child2 = child2;
-      parent.height = 1 + Math.max(child1.height, child2.height);
+      parent.height = 1 + Math.max<int>(child1.height, child2.height);
       parent.aabb.combine2(child1.aabb, child2.aabb);
       parent.parent = null;
 
@@ -588,7 +588,7 @@ class DynamicTree implements BroadPhaseStrategy {
       assert(child1 != null);
       assert(child2 != null);
 
-      index.height = 1 + Math.max(child1.height, child2.height);
+      index.height = 1 + Math.max<int>(child1.height, child2.height);
       index.aabb.combine2(child1.aabb, child2.aabb);
 
       index = index.parent;
@@ -630,7 +630,7 @@ class DynamicTree implements BroadPhaseStrategy {
         DynamicTreeNode child2 = index.child2;
 
         index.aabb.combine2(child1.aabb, child2.aabb);
-        index.height = 1 + Math.max(child1.height, child2.height);
+        index.height = 1 + Math.max<int>(child1.height, child2.height);
 
         index = index.parent;
       }
@@ -699,8 +699,8 @@ class DynamicTree implements BroadPhaseStrategy {
         A.aabb.combine2(B.aabb, G.aabb);
         C.aabb.combine2(A.aabb, F.aabb);
 
-        A.height = 1 + Math.max(B.height, G.height);
-        C.height = 1 + Math.max(A.height, F.height);
+        A.height = 1 + Math.max<int>(B.height, G.height);
+        C.height = 1 + Math.max<int>(A.height, F.height);
       } else {
         C.child2 = iG;
         A.child2 = iF;
@@ -708,8 +708,8 @@ class DynamicTree implements BroadPhaseStrategy {
         A.aabb.combine2(B.aabb, F.aabb);
         C.aabb.combine2(A.aabb, G.aabb);
 
-        A.height = 1 + Math.max(B.height, F.height);
-        C.height = 1 + Math.max(A.height, G.height);
+        A.height = 1 + Math.max<int>(B.height, F.height);
+        C.height = 1 + Math.max<int>(A.height, G.height);
       }
 
       return iC;
@@ -749,8 +749,8 @@ class DynamicTree implements BroadPhaseStrategy {
         A.aabb.combine2(C.aabb, E.aabb);
         B.aabb.combine2(A.aabb, D.aabb);
 
-        A.height = 1 + Math.max(C.height, E.height);
-        B.height = 1 + Math.max(A.height, D.height);
+        A.height = 1 + Math.max<int>(C.height, E.height);
+        B.height = 1 + Math.max<int>(A.height, D.height);
       } else {
         B.child2 = iE;
         A.child1 = iD;
@@ -758,8 +758,8 @@ class DynamicTree implements BroadPhaseStrategy {
         A.aabb.combine2(C.aabb, D.aabb);
         B.aabb.combine2(A.aabb, E.aabb);
 
-        A.height = 1 + Math.max(C.height, D.height);
-        B.height = 1 + Math.max(A.height, E.height);
+        A.height = 1 + Math.max<int>(C.height, D.height);
+        B.height = 1 + Math.max<int>(A.height, E.height);
       }
 
       return iB;
@@ -819,7 +819,7 @@ class DynamicTree implements BroadPhaseStrategy {
     int height1 = child1.height;
     int height2 = child2.height;
     int height;
-    height = 1 + Math.max(height1, height2);
+    height = 1 + Math.max<int>(height1, height2);
     assert(node.height == height);
 
     AABB aabb = AABB();

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -850,9 +850,8 @@ class DynamicTree implements BroadPhaseStrategy {
         1.0, (height - spot) * 1.0 / height, (height - spot) * 1.0 / height);
     argDraw.drawPolygon(drawVecs, 4, _color);
 
-    Vector2 textVec = argDraw
-        .getViewportTranform()
-        .getWorldToScreen(node.aabb.upperBound);
+    Vector2 textVec =
+        argDraw.getViewportTranform().getWorldToScreen(node.aabb.upperBound);
     argDraw.drawStringXY(
         textVec.x, textVec.y, "$node.id-${(spot + 1)}/$height", _color);
 

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -841,7 +841,6 @@ class DynamicTree implements BroadPhaseStrategy {
   }
 
   final Color3i _color = Color3i.zero();
-  final Vector2 _textVec = Vector2.zero();
 
   void drawTreeX(
       DebugDraw argDraw, DynamicTreeNode node, int spot, int height) {
@@ -851,11 +850,11 @@ class DynamicTree implements BroadPhaseStrategy {
         1.0, (height - spot) * 1.0 / height, (height - spot) * 1.0 / height);
     argDraw.drawPolygon(drawVecs, 4, _color);
 
-    argDraw
+    Vector2 textVec = argDraw
         .getViewportTranform()
-        .getWorldToScreen(node.aabb.upperBound, _textVec);
+        .getWorldToScreen(node.aabb.upperBound);
     argDraw.drawStringXY(
-        _textVec.x, _textVec.y, "$node.id-${(spot + 1)}/$height", _color);
+        textVec.x, textVec.y, "$node.id-${(spot + 1)}/$height", _color);
 
     if (node.child1 != null) {
       drawTreeX(argDraw, node.child1, spot + 1, height);

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -37,26 +37,26 @@ class DynamicTree implements BroadPhaseStrategy {
   static const int NULL_NODE = -1;
 
   DynamicTreeNode _root;
-  List<DynamicTreeNode> _nodes = new List<DynamicTreeNode>(16);
+  List<DynamicTreeNode> _nodes = List<DynamicTreeNode>(16);
   int _nodeCount = 0;
   int _nodeCapacity = 16;
 
   int _freeList = 0;
 
-  final List<Vector2> drawVecs = new List<Vector2>(4);
-  List<DynamicTreeNode> nodeStack = new List<DynamicTreeNode>(20);
+  final List<Vector2> drawVecs = List<Vector2>(4);
+  List<DynamicTreeNode> nodeStack = List<DynamicTreeNode>(20);
   int nodeStackIndex = 0;
 
   DynamicTree() {
     // Build a linked list for the free list.
     for (int i = _nodeCapacity - 1; i >= 0; i--) {
-      _nodes[i] = new DynamicTreeNode(i);
+      _nodes[i] = DynamicTreeNode(i);
       _nodes[i].parent = (i == _nodeCapacity - 1) ? null : _nodes[i + 1];
       _nodes[i].height = -1;
     }
 
     for (int i = 0; i < drawVecs.length; i++) {
-      drawVecs[i] = new Vector2.zero();
+      drawVecs[i] = Vector2.zero();
     }
   }
 
@@ -160,7 +160,7 @@ class DynamicTree implements BroadPhaseStrategy {
         } else {
           if (nodeStack.length - nodeStackIndex - 2 <= 0) {
             List<DynamicTreeNode> newBuffer =
-                new List<DynamicTreeNode>(nodeStack.length * 2);
+                List<DynamicTreeNode>(nodeStack.length * 2);
             BufferUtils.arraycopy(nodeStack, 0, newBuffer, 0, nodeStack.length);
             nodeStack = newBuffer;
           }
@@ -171,9 +171,9 @@ class DynamicTree implements BroadPhaseStrategy {
     }
   }
 
-  final Vector2 _r = new Vector2.zero();
-  final AABB _aabb = new AABB();
-  final RayCastInput _subInput = new RayCastInput();
+  final Vector2 _r = Vector2.zero();
+  final AABB _aabb = AABB();
+  final RayCastInput _subInput = RayCastInput();
 
   void raycast(TreeRayCastCallback callback, RayCastInput input) {
     final Vector2 p1 = input.p1;
@@ -277,7 +277,7 @@ class DynamicTree implements BroadPhaseStrategy {
       } else {
         if (nodeStack.length - nodeStackIndex - 2 <= 0) {
           List<DynamicTreeNode> newBuffer =
-              new List<DynamicTreeNode>(nodeStack.length * 2);
+              List<DynamicTreeNode>(nodeStack.length * 2);
           BufferUtils.arraycopy(nodeStack, 0, newBuffer, 0, nodeStack.length);
           nodeStack = newBuffer;
         }
@@ -396,7 +396,7 @@ class DynamicTree implements BroadPhaseStrategy {
       }
     }
 
-    AABB b = new AABB();
+    AABB b = AABB();
     while (count > 1) {
       double minCost = double.maxFinite;
       int iMin = -1, jMin = -1;
@@ -446,12 +446,12 @@ class DynamicTree implements BroadPhaseStrategy {
 
       List<DynamicTreeNode> old = _nodes;
       _nodeCapacity *= 2;
-      _nodes = new List<DynamicTreeNode>(_nodeCapacity);
+      _nodes = List<DynamicTreeNode>(_nodeCapacity);
       BufferUtils.arraycopy(old, 0, _nodes, 0, old.length);
 
       // Build a linked list for the free list.
       for (int i = _nodeCapacity - 1; i >= _nodeCount; i--) {
-        _nodes[i] = new DynamicTreeNode(i);
+        _nodes[i] = DynamicTreeNode(i);
         _nodes[i].parent = (i == _nodeCapacity - 1) ? null : _nodes[i + 1];
         _nodes[i].height = -1;
       }
@@ -482,7 +482,7 @@ class DynamicTree implements BroadPhaseStrategy {
     _nodeCount--;
   }
 
-  final AABB _combinedAABB = new AABB();
+  final AABB _combinedAABB = AABB();
 
   void _insertLeaf(int leaf_index) {
     DynamicTreeNode leaf = _nodes[leaf_index];
@@ -822,7 +822,7 @@ class DynamicTree implements BroadPhaseStrategy {
     height = 1 + Math.max(height1, height2);
     assert(node.height == height);
 
-    AABB aabb = new AABB();
+    AABB aabb = AABB();
     aabb.combine2(child1.aabb, child2.aabb);
 
     assert(MathUtils.vector2Equals(aabb.lowerBound, node.aabb.lowerBound));
@@ -840,8 +840,8 @@ class DynamicTree implements BroadPhaseStrategy {
     drawTreeX(argDraw, _root, 0, height);
   }
 
-  final Color3i _color = new Color3i.zero();
-  final Vector2 _textVec = new Vector2.zero();
+  final Color3i _color = Color3i.zero();
+  final Vector2 _textVec = Vector2.zero();
 
   void drawTreeX(
       DebugDraw argDraw, DynamicTreeNode node, int spot, int height) {

--- a/lib/src/collision/broadphase/dynamic_tree.dart
+++ b/lib/src/collision/broadphase/dynamic_tree.dart
@@ -24,14 +24,10 @@
 
 part of box2d;
 
-/**
- * A dynamic tree arranges data in a binary tree to accelerate queries such as volume queries and
- * ray casts. Leafs are proxies with an AABB. In the tree we expand the proxy AABB by _fatAABBFactor
- * so that the proxy AABB is bigger than the client object. This allows the client object to move by
- * small amounts without triggering a tree update.
- * 
- * @author daniel
- */
+/// A dynamic tree arranges data in a binary tree to accelerate queries such as volume queries and
+/// ray casts. Leafs are proxies with an AABB. In the tree we expand the proxy AABB by _fatAABBFactor
+/// so that the proxy AABB is bigger than the client object. This allows the client object to move by
+/// small amounts without triggering a tree update.
 class DynamicTree implements BroadPhaseStrategy {
   static const int MAX_STACK_SIZE = 64;
   static const int NULL_NODE = -1;
@@ -302,9 +298,7 @@ class DynamicTree implements BroadPhaseStrategy {
     return 1 + Math.max<int>(height1, height2);
   }
 
-  /**
-   * Validate this tree. For testing.
-   */
+  /// Validate this tree. For testing.
   void validate() {
     _validateStructure(_root);
     _validateMetrics(_root);
@@ -372,9 +366,7 @@ class DynamicTree implements BroadPhaseStrategy {
     return totalArea / rootArea;
   }
 
-  /**
-   * Build an optimal tree. Very expensive. For testing.
-   */
+  /// Build an optimal tree. Very expensive. For testing.
   void rebuildBottomUp() {
     List<int> nodes = BufferUtils.allocClearIntList(_nodeCount);
     int count = 0;
@@ -470,9 +462,7 @@ class DynamicTree implements BroadPhaseStrategy {
     return treeNode;
   }
 
-  /**
-   * returns a node to the pool
-   */
+  /// returns a node to the pool
   void _freeNode(DynamicTreeNode node) {
     assert(node != null);
     assert(0 < _nodeCount);

--- a/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
+++ b/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
@@ -307,7 +307,7 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
     }
     int height1 = _computeHeight(_child1[node]);
     int height2 = _computeHeight(_child2[node]);
-    return 1 + Math.max(height1, height2);
+    return 1 + Math.max<int>(height1, height2);
   }
 
   /**
@@ -510,7 +510,7 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
       assert(child1 != NULL_NODE);
       assert(child2 != NULL_NODE);
 
-      _height[index] = 1 + Math.max(_height[child1], _height[child2]);
+      _height[index] = 1 + Math.max<int>(_height[child1], _height[child2]);
       _aabb[index].combine2(_aabb[child1], _aabb[child2]);
 
       index = _parent[index];
@@ -554,7 +554,7 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         int child2 = _child2[index];
 
         _aabb[index].combine2(_aabb[child1], _aabb[child2]);
-        _height[index] = 1 + Math.max(_height[child1], _height[child2]);
+        _height[index] = 1 + Math.max<int>(_height[child1], _height[child2]);
 
         index = _parent[index];
       }
@@ -623,8 +623,8 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         _aabb[A].combine2(_aabb[B], _aabb[G]);
         _aabb[C].combine2(_aabb[A], _aabb[F]);
 
-        _height[A] = 1 + Math.max(_height[B], _height[G]);
-        _height[C] = 1 + Math.max(_height[A], _height[F]);
+        _height[A] = 1 + Math.max<int>(_height[B], _height[G]);
+        _height[C] = 1 + Math.max<int>(_height[A], _height[F]);
       } else {
         _child2[C] = iG;
         _child2[A] = iF;
@@ -632,8 +632,8 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         _aabb[A].combine2(_aabb[B], _aabb[F]);
         _aabb[C].combine2(_aabb[A], _aabb[G]);
 
-        _height[A] = 1 + Math.max(_height[B], _height[F]);
-        _height[C] = 1 + Math.max(_height[A], _height[G]);
+        _height[A] = 1 + Math.max<int>(_height[B], _height[F]);
+        _height[C] = 1 + Math.max<int>(_height[A], _height[G]);
       }
 
       return iC;
@@ -673,8 +673,8 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         _aabb[A].combine2(_aabb[C], _aabb[E]);
         _aabb[B].combine2(_aabb[A], _aabb[D]);
 
-        _height[A] = 1 + Math.max(_height[C], _height[E]);
-        _height[B] = 1 + Math.max(_height[A], _height[D]);
+        _height[A] = 1 + Math.max<int>(_height[C], _height[E]);
+        _height[B] = 1 + Math.max<int>(_height[A], _height[D]);
       } else {
         _child2[B] = iE;
         _child1[A] = iD;
@@ -682,8 +682,8 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         _aabb[A].combine2(_aabb[C], _aabb[D]);
         _aabb[B].combine2(_aabb[A], _aabb[E]);
 
-        _height[A] = 1 + Math.max(_height[C], _height[D]);
-        _height[B] = 1 + Math.max(_height[A], _height[E]);
+        _height[A] = 1 + Math.max<int>(_height[C], _height[D]);
+        _height[B] = 1 + Math.max<int>(_height[A], _height[E]);
       }
 
       return iB;
@@ -742,7 +742,7 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
     int height1 = _height[child1];
     int height2 = _height[child2];
     int height;
-    height = 1 + Math.max(height1, height2);
+    height = 1 + Math.max<int>(height1, height2);
     assert(_height[node] == height);
 
     AABB aabb = new AABB();

--- a/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
+++ b/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
@@ -310,9 +310,7 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
     return 1 + Math.max<int>(height1, height2);
   }
 
-  /**
-   * Validate this tree. For testing.
-   */
+  /// Validate this tree. For testing.
   void validate() {
     _validateStructure(_root);
     _validateMetrics(_root);
@@ -391,9 +389,7 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
     return node;
   }
 
-  /**
-   * returns a node to the pool
-   */
+  /// returns a node to the pool
   void _freeNode(int node) {
     assert(node != NULL_NODE);
     assert(0 < _nodeCount);

--- a/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
+++ b/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
@@ -764,7 +764,6 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
   }
 
   final Color3i _color = new Color3i.zero();
-  final Vector2 _textVec = new Vector2.zero();
 
   void drawTreeX(DebugDraw argDraw, int node, int spot, int height) {
     AABB a = _aabb[node];
@@ -774,9 +773,11 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         1.0, (height - spot) * 1.0 / height, (height - spot) * 1.0 / height);
     argDraw.drawPolygon(drawVecs, 4, _color);
 
-    argDraw.getViewportTranform().getWorldToScreen(a.upperBound, _textVec);
+    Vector2 textVec = argDraw
+        .getViewportTranform()
+        .getWorldToScreen(a.upperBound);
     argDraw.drawStringXY(
-        _textVec.x, _textVec.y, "$node-${(spot + 1)}/$height", _color);
+        textVec.x, textVec.y, "$node-${(spot + 1)}/$height", _color);
 
     int c1 = _child1[node];
     int c2 = _child2[node];

--- a/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
+++ b/lib/src/collision/broadphase/dynamic_tree_flatnodes.dart
@@ -773,9 +773,8 @@ class DynamicTreeFlatNodes implements BroadPhaseStrategy {
         1.0, (height - spot) * 1.0 / height, (height - spot) * 1.0 / height);
     argDraw.drawPolygon(drawVecs, 4, _color);
 
-    Vector2 textVec = argDraw
-        .getViewportTranform()
-        .getWorldToScreen(a.upperBound);
+    Vector2 textVec =
+        argDraw.getViewportTranform().getWorldToScreen(a.upperBound);
     argDraw.drawStringXY(
         textVec.x, textVec.y, "$node-${(spot + 1)}/$height", _color);
 

--- a/lib/src/collision/broadphase/dynamic_tree_node.dart
+++ b/lib/src/collision/broadphase/dynamic_tree_node.dart
@@ -25,9 +25,7 @@
 part of box2d;
 
 class DynamicTreeNode {
-  /**
-   * Enlarged AABB
-   */
+  /// Enlarged AABB
   final AABB aabb = new AABB();
 
   Object userData;

--- a/lib/src/collision/broadphase/pair.dart
+++ b/lib/src/collision/broadphase/pair.dart
@@ -24,10 +24,8 @@
 
 part of box2d;
 
-/**
- * Java note: at the "creation" of each node, a random key is given to that node, and that's what we
- * sort from.
- */
+/// Java note: at the "creation" of each node, a random key is given to that node, and that's what we
+/// sort from.
 class Pair implements Comparable<Pair> {
   int proxyIdA = 0;
   int proxyIdB = 0;

--- a/lib/src/collision/collision.dart
+++ b/lib/src/collision/collision.dart
@@ -355,7 +355,7 @@ class Collision {
 
     // Find the min separating edge.
     int normalIndex = 0;
-    double separation = -double.MAX_FINITE;
+    double separation = -double.maxFinite;
     final double radius = polygon.radius + circle.radius;
     final int vertexCount = polygon.count;
     double s;
@@ -537,14 +537,14 @@ class Collision {
     final Rot xfq = _xf.q;
 
     int bestIndex = 0;
-    double maxSeparation = -double.MAX_FINITE;
+    double maxSeparation = -double.maxFinite;
     for (int i = 0; i < count1; i++) {
       // Get poly1 normal in frame2.
       Rot.mulToOutUnsafe(xfq, n1s[i], _n);
       Transform.mulToOutUnsafeVec2(_xf, v1s[i], _v1);
 
       // Find deepest point for normal i.
-      double si = double.MAX_FINITE;
+      double si = double.maxFinite;
       for (int j = 0; j < count2; ++j) {
         Vector2 v2sj = v2s[j];
         double sij = _n.x * (v2sj.x - _v1.x) + _n.y * (v2sj.y - _v1.y);
@@ -600,7 +600,7 @@ class Collision {
 
     // Find the incident edge on poly2.
     int index = 0;
-    double minDot = double.MAX_FINITE;
+    double minDot = double.maxFinite;
     for (int i = 0; i < count2; ++i) {
       Vector2 b = normals2[i];
       double dot = normal1x * b.x + normal1y * b.y;
@@ -1412,7 +1412,7 @@ class EPCollider {
   void computeEdgeSeparation(EPAxis axis) {
     axis.type = EPAxisType.EDGE_A;
     axis.index = front ? 0 : 1;
-    axis.separation = double.MAX_FINITE;
+    axis.separation = double.maxFinite;
     double nx = normal.x;
     double ny = normal.y;
 
@@ -1433,7 +1433,7 @@ class EPCollider {
   void computePolygonSeparation(EPAxis axis) {
     axis.type = EPAxisType.UNKNOWN;
     axis.index = -1;
-    axis.separation = -double.MAX_FINITE;
+    axis.separation = -double.maxFinite;
 
     _perp.x = -normal.y;
     _perp.y = normal.x;

--- a/lib/src/collision/collision.dart
+++ b/lib/src/collision/collision.dart
@@ -1,40 +1,36 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * Java-specific class for returning edge results
- */
+/// Java-specific class for returning edge results
 class _EdgeResults {
   double separation = 0.0;
   int edgeIndex = 0;
 }
 
-/**
- * Used for computing contact manifolds.
- */
+/// Used for computing contact manifolds.
 class ClipVertex {
   final Vector2 v = new Vector2.zero();
   final ContactID id = new ContactID();
@@ -51,33 +47,22 @@ class ClipVertex {
   }
 }
 
-/**
- * This is used for determining the state of contact points.
- *
- * @author Daniel Murphy
- */
+/// This is used for determining the state of contact points.
 enum PointState {
-  /**
-   * point does not exist
-   */
+  /// point does not exist
   NULL_STATE,
-  /**
-   * point was added in the update
-   */
+
+  /// point was added in the update
   ADD_STATE,
-  /**
-   * point persisted across the update
-   */
+
+  /// point persisted across the update
   PERSIST_STATE,
-  /**
-   * point was removed in the update
-   */
+
+  /// point was removed in the update
   REMOVE_STATE
 }
 
-/**
- * This structure is used to keep track of the best separating axis.
- */
+/// This structure is used to keep track of the best separating axis.
 
 enum EPAxisType { UNKNOWN, EDGE_A, EDGE_B }
 
@@ -87,9 +72,7 @@ class EPAxis {
   double separation = 0.0;
 }
 
-/**
- * This holds polygon B expressed in frame A.
- */
+/// This holds polygon B expressed in frame A.
 class TempPolygon {
   final List<Vector2> vertices = new List<Vector2>(Settings.maxPolygonVertices);
   final List<Vector2> normals = new List<Vector2>(Settings.maxPolygonVertices);
@@ -103,9 +86,7 @@ class TempPolygon {
   }
 }
 
-/**
- * Reference face used for clipping
- */
+/// Reference face used for clipping
 class _ReferenceFace {
   int i1 = 0, i2 = 0;
   final Vector2 v1 = new Vector2.zero();
@@ -119,11 +100,9 @@ class _ReferenceFace {
   double sideOffset2 = 0.0;
 }
 
-/**
- * Functions used for computing contact points, distance queries, and TOI queries. Collision methods
- * are non-static for pooling speed, retrieve a collision object from the {@link SingletonPool}.
- * Should not be finalructed.
- */
+/// Functions used for computing contact points, distance queries, and TOI queries. Collision methods
+/// are non-static for pooling speed, retrieve a collision object from the {@link SingletonPool}.
+/// Should not be finalructed.
 class Collision {
   static const int NULL_FEATURE = 0x3FFFFFFF; // Integer.MAX_VALUE;
 
@@ -142,15 +121,7 @@ class Collision {
   final SimplexCache _cache = new SimplexCache();
   final DistanceOutput _output = new DistanceOutput();
 
-  /**
-   * Determine if two generic shapes overlap.
-   *
-   * @param shapeA
-   * @param shapeB
-   * @param xfA
-   * @param xfB
-   * @return
-   */
+  /// Determine if two generic shapes overlap.
   bool testOverlap(Shape shapeA, int indexA, Shape shapeB, int indexB,
       Transform xfA, Transform xfB) {
     _input.proxyA.set(shapeA, indexA);
@@ -166,16 +137,9 @@ class Collision {
     return _output.distance < 10.0 * Settings.EPSILON;
   }
 
-  /**
-   * Compute the point states given two manifolds. The states pertain to the transition from
-   * manifold1 to manifold2. So state1 is either persist or remove while state2 is either add or
-   * persist.
-   *
-   * @param state1
-   * @param state2
-   * @param manifold1
-   * @param manifold2
-   */
+  /// Compute the point states given two manifolds. The states pertain to the transition from
+  /// manifold1 to manifold2. So state1 is either persist or remove while state2 is either add or
+  /// persist.
   static void getPointStates(
       final List<PointState> state1,
       final List<PointState> state2,
@@ -215,15 +179,7 @@ class Collision {
     }
   }
 
-  /**
-   * Clipping for contact manifolds. Sutherland-Hodgman clipping.
-   *
-   * @param vOut
-   * @param vIn
-   * @param normal
-   * @param offset
-   * @return
-   */
+  /// Clipping for contact manifolds. Sutherland-Hodgman clipping.
   static int clipSegmentToLine(
       final List<ClipVertex> vOut,
       final List<ClipVertex> vIn,
@@ -275,15 +231,7 @@ class Collision {
   // djm pooling
   static Vector2 _d = new Vector2.zero();
 
-  /**
-   * Compute the collision manifold between two circles.
-   *
-   * @param manifold
-   * @param circle1
-   * @param xfA
-   * @param circle2
-   * @param xfB
-   */
+  /// Compute the collision manifold between two circles.
   void collideCircles(Manifold manifold, final CircleShape circle1,
       final Transform xfA, final CircleShape circle2, final Transform xfB) {
     manifold.pointCount = 0;
@@ -321,15 +269,7 @@ class Collision {
 
   // djm pooling, and from above
 
-  /**
-   * Compute the collision manifold between a polygon and a circle.
-   *
-   * @param manifold
-   * @param polygon
-   * @param xfA
-   * @param circle
-   * @param xfB
-   */
+  /// Compute the collision manifold between a polygon and a circle.
   void collidePolygonAndCircle(Manifold manifold, final PolygonShape polygon,
       final Transform xfA, final CircleShape circle, final Transform xfB) {
     manifold.pointCount = 0;
@@ -341,6 +281,7 @@ class Collision {
     // Transform.mulTransToOut(xfA, c, cLocal);
     // final double cLocalx = cLocal.x;
     // final double cLocaly = cLocal.y;
+
     // after inline:
     final Vector2 circlep = circle.p;
     final Rot xfBq = xfB.q;
@@ -515,16 +456,7 @@ class Collision {
   final Vector2 _n = new Vector2.zero();
   final Vector2 _v1 = new Vector2.zero();
 
-  /**
-   * Find the max separation between poly1 and poly2 using edge normals from poly1.
-   *
-   * @param edgeIndex
-   * @param poly1
-   * @param xf1
-   * @param poly2
-   * @param xf2
-   * @return
-   */
+  /// Find the max separation between poly1 and poly2 using edge normals from poly1.
   void findMaxSeparation(_EdgeResults results, final PolygonShape poly1,
       final Transform xf1, final PolygonShape poly2, final Transform xf2) {
     int count1 = poly1.count;
@@ -647,15 +579,7 @@ class Collision {
   final List<ClipVertex> _clipPoints1 = new List<ClipVertex>(2);
   final List<ClipVertex> _clipPoints2 = new List<ClipVertex>(2);
 
-  /**
-   * Compute the collision manifold between two polygons.
-   *
-   * @param manifold
-   * @param polygon1
-   * @param xf1
-   * @param polygon2
-   * @param xf2
-   */
+  /// Compute the collision manifold between two polygons.
   void collidePolygons(Manifold manifold, final PolygonShape polyA,
       final Transform xfA, final PolygonShape polyB, final Transform xfB) {
     // Find edge normal of max separation on A - return if separating axis is found
@@ -972,9 +896,7 @@ class Collision {
     _collider.collide(manifold, edgeA, xfA, polygonB, xfB);
   }
 
-  /**
-   * This class collides and edge and a polygon, taking into account edge adjacency.
-   */
+  /// This class collides and edge and a polygon, taking into account edge adjacency.
 }
 
 enum VertexType { ISOLATED, CONCAVE, CONVEX }

--- a/lib/src/collision/contactid.dart
+++ b/lib/src/collision/contactid.dart
@@ -27,7 +27,7 @@ part of box2d;
 enum ContactIDType { VERTEX, FACE }
 
 class ContactID implements Comparable<ContactID> {
-  Int8List _data = new Int8List(4);
+  Int8List _data = Int8List(4);
 
   void set indexA(int v) {
     _data[0] = v;

--- a/lib/src/collision/contactid.dart
+++ b/lib/src/collision/contactid.dart
@@ -81,9 +81,7 @@ class ContactID implements Comparable<ContactID> {
     typeB = tempA;
   }
 
-  /**
-   * zeros out the data
-   */
+  /// zeros out the data
   void zero() {
     indexA = 0;
     indexB = 0;

--- a/lib/src/collision/distance.dart
+++ b/lib/src/collision/distance.dart
@@ -1,32 +1,30 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * GJK using Voronoi regions (Christer Ericson) and Barycentric coordinates.
- */
+/// GJK using Voronoi regions (Christer Ericson) and Barycentric coordinates.
 class _SimplexVertex {
   final Vector2 wA = new Vector2.zero(); // support point in shapeA
   final Vector2 wB = new Vector2.zero(); // support point in shapeB
@@ -46,12 +44,14 @@ class _SimplexVertex {
 }
 
 class SimplexCache {
-  /** length or area */
+  /// length or area
   double metric = 0.0;
   int count = 0;
-  /** vertices on shape A */
+
+  /// vertices on shape A
   final List<int> indexA = BufferUtils.allocClearIntList(3);
-  /** vertices on shape B */
+
+  /// vertices on shape B
   final List<int> indexB = BufferUtils.allocClearIntList(3);
 
   SimplexCache() {
@@ -182,11 +182,7 @@ class _Simplex {
   final Vector2 _case2 = new Vector2.zero();
   final Vector2 _case22 = new Vector2.zero();
 
-  /**
-   * this returns pooled objects. don't keep or modify them
-   *
-   * @return
-   */
+  /// This returns pooled objects. don't keep or modify them
   void getClosestPoint(final Vector2 out) {
     switch (count) {
       case 0:
@@ -303,9 +299,7 @@ class _Simplex {
   }
 
   // djm pooled from above
-  /**
-   * Solve a line segment using barycentric coordinates.
-   */
+  /// Solve a line segment using barycentric coordinates.
   void solve2() {
     // Solve a line segment using barycentric coordinates.
     //
@@ -369,14 +363,12 @@ class _Simplex {
   final Vector2 _w2 = new Vector2.zero();
   final Vector2 _w3 = new Vector2.zero();
 
-  /**
-   * Solve a line segment using barycentric coordinates.<br/>
-   * Possible regions:<br/>
-   * - points[2]<br/>
-   * - edge points[0]-points[2]<br/>
-   * - edge points[1]-points[2]<br/>
-   * - inside the triangle
-   */
+  /// Solve a line segment using barycentric coordinates.<br/>
+  /// Possible regions:<br/>
+  /// - points[2]<br/>
+  /// - edge points[0]-points[2]<br/>
+  /// - edge points[1]-points[2]<br/>
+  /// - inside the triangle
   void solve3() {
     _w1.setFrom(v1.w);
     _w2.setFrom(v2.w);
@@ -502,10 +494,8 @@ class DistanceProxy {
     radius = 0.0;
   }
 
-  /**
-   * Initialize the proxy using the given shape. The shape must remain in scope while the proxy is
-   * in use.
-   */
+  /// Initialize the proxy using the given shape. The shape must remain in scope while the proxy is
+  /// in use.
   void set(final Shape shape, int index) {
     switch (shape.shapeType) {
       case ShapeType.CIRCLE:
@@ -551,12 +541,7 @@ class DistanceProxy {
     }
   }
 
-  /**
-   * Get the supporting vertex index in the given direction.
-   *
-   * @param d
-   * @return
-   */
+  /// Get the supporting vertex index in the given direction.
   int getSupport(final Vector2 d) {
     int bestIndex = 0;
     double bestValue = vertices[0].dot(d);
@@ -571,12 +556,7 @@ class DistanceProxy {
     return bestIndex;
   }
 
-  /**
-   * Get the supporting vertex in the given direction.
-   *
-   * @param d
-   * @return
-   */
+  /// Get the supporting vertex in the given direction.
   Vector2 getSupportVertex(final Vector2 d) {
     int bestIndex = 0;
     double bestValue = vertices[0].dot(d);
@@ -591,21 +571,12 @@ class DistanceProxy {
     return vertices[bestIndex];
   }
 
-  /**
-   * Get the vertex count.
-   *
-   * @return
-   */
+  /// Get the vertex count.
   int getVertexCount() {
     return _count;
   }
 
-  /**
-   * Get a vertex by index. Used by Distance.
-   *
-   * @param index
-   * @return
-   */
+  /// Get a vertex by index. Used by Distance.
   Vector2 getVertex(int index) {
     assert(0 <= index && index < _count);
     return vertices[index];
@@ -627,15 +598,9 @@ class Distance {
   final Vector2 _temp = new Vector2.zero();
   final Vector2 _normal = new Vector2.zero();
 
-  /**
-   * Compute the closest points between two shapes. Supports any combination of: CircleShape and
-   * PolygonShape. The simplex cache is input/output. On the first call set SimplexCache.count to
-   * zero.
-   *
-   * @param output
-   * @param cache
-   * @param input
-   */
+  /// Compute the closest points between two shapes. Supports any combination of: CircleShape and
+  /// PolygonShape. The simplex cache is input/output. On the first call set SimplexCache.count to
+  /// zero.
   void distance(final DistanceOutput output, final SimplexCache cache,
       final DistanceInput input) {
     GJK_CALLS++;

--- a/lib/src/collision/distance_input.dart
+++ b/lib/src/collision/distance_input.dart
@@ -24,12 +24,8 @@
 
 part of box2d;
 
-/**
- * Input for Distance.
- * You have to option to use the shape radii
- * in the computation.
- *
- */
+/// Input for Distance.
+/// You have to option to use the shape radii in the computation.
 class DistanceInput {
   DistanceProxy proxyA = new DistanceProxy();
   DistanceProxy proxyB = new DistanceProxy();

--- a/lib/src/collision/distance_output.dart
+++ b/lib/src/collision/distance_output.dart
@@ -24,18 +24,16 @@
 
 part of box2d;
 
-/**
- * Output for Distance.
- */
+/// Output for Distance.
 class DistanceOutput {
-  /** Closest point on shapeA */
+  /// Closest point on shapeA
   final Vector2 pointA = new Vector2.zero();
 
-  /** Closest point on shapeB */
+  /// Closest point on shapeB
   final Vector2 pointB = new Vector2.zero();
 
   double distance = 0.0;
 
-  /** number of gjk iterations used */
+  /// number of gjk iterations used
   int iterations = 0;
 }

--- a/lib/src/collision/manifold.dart
+++ b/lib/src/collision/manifold.dart
@@ -68,11 +68,11 @@ class Manifold {
    * creates a manifold with 0 points, with it's points array full of instantiated ManifoldPoints.
    */
   Manifold()
-      : points = new List<ManifoldPoint>(Settings.maxManifoldPoints),
-        localNormal = new Vector2.zero(),
-        localPoint = new Vector2.zero() {
+      : points = List<ManifoldPoint>(Settings.maxManifoldPoints),
+        localNormal = Vector2.zero(),
+        localPoint = Vector2.zero() {
     for (int i = 0; i < Settings.maxManifoldPoints; i++) {
-      points[i] = new ManifoldPoint();
+      points[i] = ManifoldPoint();
     }
   }
 
@@ -82,14 +82,14 @@ class Manifold {
    * @param other
    */
   Manifold.copy(Manifold other)
-      : points = new List<ManifoldPoint>(Settings.maxManifoldPoints),
+      : points = List<ManifoldPoint>(Settings.maxManifoldPoints),
         localNormal = other.localNormal.clone(),
         localPoint = other.localPoint.clone(),
         pointCount = other.pointCount {
     type = other.type;
     // djm: this is correct now
     for (int i = 0; i < Settings.maxManifoldPoints; i++) {
-      points[i] = new ManifoldPoint.copy(other.points[i]);
+      points[i] = ManifoldPoint.copy(other.points[i]);
     }
   }
 

--- a/lib/src/collision/manifold.dart
+++ b/lib/src/collision/manifold.dart
@@ -24,49 +24,45 @@
 
 part of box2d;
 
-/**
- * A manifold for two touching convex shapes. Box2D supports multiple types of contact:
- * <ul>
- * <li>clip point versus plane with radius</li>
- * <li>point versus point with radius (circles)</li>
- * </ul>
- * The local point usage depends on the manifold type:
- * <ul>
- * <li>e_circles: the local center of circleA</li>
- * <li>e_faceA: the center of faceA</li>
- * <li>e_faceB: the center of faceB</li>
- * </ul>
- * Similarly the local normal usage:
- * <ul>
- * <li>e_circles: not used</li>
- * <li>e_faceA: the normal on polygonA</li>
- * <li>e_faceB: the normal on polygonB</li>
- * </ul>
- * We store contacts in this way so that position correction can account for movement, which is
- * critical for continuous physics. All contact scenarios must be expressed in one of these types.
- * This structure is stored across time steps, so we keep it small.
- */
+/// A manifold for two touching convex shapes. Box2D supports multiple types of contact:
+/// <ul>
+/// <li>clip point versus plane with radius</li>
+/// <li>point versus point with radius (circles)</li>
+/// </ul>
+/// The local point usage depends on the manifold type:
+/// <ul>
+/// <li>e_circles: the local center of circleA</li>
+/// <li>e_faceA: the center of faceA</li>
+/// <li>e_faceB: the center of faceB</li>
+/// </ul>
+/// Similarly the local normal usage:
+/// <ul>
+/// <li>e_circles: not used</li>
+/// <li>e_faceA: the normal on polygonA</li>
+/// <li>e_faceB: the normal on polygonB</li>
+/// </ul>
+/// We store contacts in this way so that position correction can account for movement, which is
+/// critical for continuous physics. All contact scenarios must be expressed in one of these types.
+/// This structure is stored across time steps, so we keep it small.
 
 enum ManifoldType { CIRCLES, FACE_A, FACE_B }
 
 class Manifold {
-  /** The points of contact. */
+  /// The points of contact.
   final List<ManifoldPoint> points;
 
-  /** not use for Type::e_points */
+  /// not use for Type::e_points
   final Vector2 localNormal;
 
-  /** usage depends on manifold type */
+  /// usage depends on manifold type
   final Vector2 localPoint;
 
   ManifoldType type = ManifoldType.CIRCLES;
 
-  /** The number of manifold points. */
+  /// The number of manifold points.
   int pointCount = 0;
 
-  /**
-   * creates a manifold with 0 points, with it's points array full of instantiated ManifoldPoints.
-   */
+  /// creates a manifold with 0 points, with it's points array full of instantiated ManifoldPoints.
   Manifold()
       : points = List<ManifoldPoint>(Settings.maxManifoldPoints),
         localNormal = Vector2.zero(),
@@ -76,11 +72,7 @@ class Manifold {
     }
   }
 
-  /**
-   * Creates this manifold as a copy of the other
-   * 
-   * @param other
-   */
+  /// Creates this manifold as a copy of the other
   Manifold.copy(Manifold other)
       : points = List<ManifoldPoint>(Settings.maxManifoldPoints),
         localNormal = other.localNormal.clone(),
@@ -93,11 +85,9 @@ class Manifold {
     }
   }
 
-  /**
-   * copies this manifold from the given one
-   * 
-   * @param cp manifold to copy from
-   */
+  /// copies this manifold from the given one
+  ///
+  /// @param cp manifold to copy from
   void set(Manifold cp) {
     for (int i = 0; i < cp.pointCount; i++) {
       points[i].set(cp.points[i]);

--- a/lib/src/collision/manifold_point.dart
+++ b/lib/src/collision/manifold_point.dart
@@ -24,49 +24,44 @@
 
 part of box2d;
 
-/**
- * A manifold point is a contact point belonging to a contact
- * manifold. It holds details related to the geometry and dynamics
- * of the contact points.
- * The local point usage depends on the manifold type:
- * <ul><li>e_circles: the local center of circleB</li>
- * <li>e_faceA: the local center of cirlceB or the clip point of polygonB</li>
- * <li>e_faceB: the clip point of polygonA</li></ul>
- * This structure is stored across time steps, so we keep it small.<br/>
- * Note: the impulses are used for internal caching and may not
- * provide reliable contact forces, especially for high speed collisions.
- */
+/// A manifold point is a contact point belonging to a contact
+/// manifold. It holds details related to the geometry and dynamics
+/// of the contact points.
+/// The local point usage depends on the manifold type:
+/// <ul><li>e_circles: the local center of circleB</li>
+/// <li>e_faceA: the local center of cirlceB or the clip point of polygonB</li>
+/// <li>e_faceB: the clip point of polygonA</li></ul>
+/// This structure is stored across time steps, so we keep it small.<br/>
+/// Note: the impulses are used for internal caching and may not
+/// provide reliable contact forces, especially for high speed collisions.
 class ManifoldPoint {
-  /** usage depends on manifold type */
+  /// usage depends on manifold type
   final Vector2 localPoint;
-  /** the non-penetration impulse */
+
+  /// the non-penetration impulse
   double normalImpulse = 0.0;
-  /** the friction impulse */
+
+  /// the friction impulse
   double tangentImpulse = 0.0;
-  /** uniquely identifies a contact point between two shapes */
+
+  /// uniquely identifies a contact point between two shapes
   final ContactID id;
 
-  /**
-   * Blank manifold point with everything zeroed out.
-   */
+  /// Blank manifold point with everything zeroed out.
   ManifoldPoint()
       : localPoint = new Vector2.zero(),
         id = new ContactID();
 
-  /**
-   * Creates a manifold point as a copy of the given point
-   * @param cp point to copy from
-   */
+  /// Creates a manifold point as a copy of the given point
+  /// @param cp point to copy from
   ManifoldPoint.copy(final ManifoldPoint cp)
       : localPoint = cp.localPoint.clone(),
         normalImpulse = cp.normalImpulse,
         tangentImpulse = cp.tangentImpulse,
         id = new ContactID.copy(cp.id);
 
-  /**
-   * Sets this manifold point form the given one
-   * @param cp the point to copy from
-   */
+  /// Sets this manifold point form the given one
+  /// @param cp the point to copy from
   void set(final ManifoldPoint cp) {
     localPoint.setFrom(cp.localPoint);
     normalImpulse = cp.normalImpulse;

--- a/lib/src/collision/raycast_input.dart
+++ b/lib/src/collision/raycast_input.dart
@@ -24,9 +24,7 @@
 
 part of box2d;
 
-/**
- * Ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
- */
+/// Ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
 class RayCastInput {
   final Vector2 p1 = new Vector2.zero(), p2 = new Vector2.zero();
   double maxFraction = 0.0;

--- a/lib/src/collision/raycast_output.dart
+++ b/lib/src/collision/raycast_output.dart
@@ -29,7 +29,7 @@ part of box2d;
  * come from b2RayCastInput.
  */
 class RayCastOutput {
-  final Vector2 normal = new Vector2.zero();
+  final Vector2 normal = Vector2.zero();
   double fraction = 0.0;
 
   void set(final RayCastOutput rco) {

--- a/lib/src/collision/raycast_output.dart
+++ b/lib/src/collision/raycast_output.dart
@@ -24,10 +24,8 @@
 
 part of box2d;
 
-/**
- * Ray-cast output data. The ray hits at p1 + fraction * (p2 - p1), where p1 and p2
- * come from b2RayCastInput.
- */
+/// Ray-cast output data. The ray hits at p1 + fraction * (p2 - p1), where p1 and p2
+/// come from b2RayCastInput.
 class RayCastOutput {
   final Vector2 normal = Vector2.zero();
   double fraction = 0.0;

--- a/lib/src/collision/shapes/chain_shape.dart
+++ b/lib/src/collision/shapes/chain_shape.dart
@@ -165,6 +165,21 @@ class ChainShape extends Shape {
   }
 
   /**
+   * Returns the vertex at the given position (index).
+   * 
+   * @param index the index of the vertex 0 <= index < getVertexCount( )
+   * @param vertex output vertex object, must be initialized
+   */
+  Vector2 getVertex(int index) {
+    assert(index >= 0 && index < _vertices.length);
+    return _vertices[index].clone();
+  }
+
+  int getVertexCount() {
+    return _vertices.length;
+  }
+
+  /**
    * Create a loop. This automatically adjusts connectivity.
    * 
    * @param vertices an array of vertices, these are copied

--- a/lib/src/collision/shapes/chain_shape.dart
+++ b/lib/src/collision/shapes/chain_shape.dart
@@ -34,11 +34,11 @@ part of box2d;
 class ChainShape extends Shape {
   List<Vector2> _vertices;
   int _count = 0;
-  final Vector2 _prevVertex = new Vector2.zero(),
-      _nextVertex = new Vector2.zero();
+  final Vector2 _prevVertex = Vector2.zero(),
+      _nextVertex = Vector2.zero();
   bool _hasPrevVertex = false, _hasNextVertex = false;
 
-  final EdgeShape _pool0 = new EdgeShape();
+  final EdgeShape _pool0 = EdgeShape();
 
   ChainShape() : super(ShapeType.CHAIN) {
     radius = Settings.polygonRadius;
@@ -155,7 +155,7 @@ class ChainShape extends Shape {
   }
 
   Shape clone() {
-    ChainShape clone = new ChainShape();
+    ChainShape clone = ChainShape();
     clone.createChain(_vertices, _count);
     clone._prevVertex.setFrom(_prevVertex);
     clone._nextVertex.setFrom(_nextVertex);
@@ -189,7 +189,7 @@ class ChainShape extends Shape {
     assert(_vertices == null && _count == 0);
     assert(count >= 3);
     _count = count + 1;
-    _vertices = new List<Vector2>(_count);
+    _vertices = List<Vector2>(_count);
     for (int i = 1; i < count; i++) {
       Vector2 v1 = vertices[i - 1];
       Vector2 v2 = vertices[i];
@@ -200,9 +200,9 @@ class ChainShape extends Shape {
       }
     }
     for (int i = 0; i < count; i++) {
-      _vertices[i] = new Vector2.copy(vertices[i]);
+      _vertices[i] = Vector2.copy(vertices[i]);
     }
-    _vertices[count] = new Vector2.copy(_vertices[0]);
+    _vertices[count] = Vector2.copy(_vertices[0]);
     _prevVertex.setFrom(_vertices[_count - 2]);
     _nextVertex.setFrom(_vertices[1]);
     _hasPrevVertex = true;
@@ -219,7 +219,7 @@ class ChainShape extends Shape {
     assert(_vertices == null && _count == 0);
     assert(count >= 2);
     _count = count;
-    _vertices = new List<Vector2>(_count);
+    _vertices = List<Vector2>(_count);
     for (int i = 1; i < _count; i++) {
       Vector2 v1 = vertices[i - 1];
       Vector2 v2 = vertices[i];
@@ -230,7 +230,7 @@ class ChainShape extends Shape {
       }
     }
     for (int i = 0; i < _count; i++) {
-      _vertices[i] = new Vector2.copy(vertices[i]);
+      _vertices[i] = Vector2.copy(vertices[i]);
     }
     _hasPrevVertex = false;
     _hasNextVertex = false;

--- a/lib/src/collision/shapes/chain_shape.dart
+++ b/lib/src/collision/shapes/chain_shape.dart
@@ -34,8 +34,7 @@ part of box2d;
 class ChainShape extends Shape {
   List<Vector2> _vertices;
   int _count = 0;
-  final Vector2 _prevVertex = Vector2.zero(),
-      _nextVertex = Vector2.zero();
+  final Vector2 _prevVertex = Vector2.zero(), _nextVertex = Vector2.zero();
   bool _hasPrevVertex = false, _hasNextVertex = false;
 
   final EdgeShape _pool0 = EdgeShape();

--- a/lib/src/collision/shapes/chain_shape.dart
+++ b/lib/src/collision/shapes/chain_shape.dart
@@ -24,13 +24,10 @@
 
 part of box2d;
 
-/***
- * A chain shape is a free form sequence of line segments. The chain has two-sided collision, so you
- * can use inside and outside collision. Therefore, you may use any winding order. Connectivity
- * information is used to create smooth collisions. WARNING: The chain will not collide properly if
- * there are self-intersections.
- */
-
+/// A chain shape is a free form sequence of line segments. The chain has two-sided collision, so you
+/// can use inside and outside collision. Therefore, you may use any winding order. Connectivity
+/// information is used to create smooth collisions. WARNING: The chain will not collide properly if
+/// there are self-intersections.
 class ChainShape extends Shape {
   List<Vector2> _vertices;
   int _count = 0;
@@ -52,9 +49,7 @@ class ChainShape extends Shape {
     return _count - 1;
   }
 
-  /**
-   * Get a child edge.
-   */
+  /// Get a child edge.
   void getChildEdge(EdgeShape edge, int index) {
     assert(0 <= index && index < _count - 1);
     edge.radius = radius;
@@ -163,12 +158,10 @@ class ChainShape extends Shape {
     return clone;
   }
 
-  /**
-   * Returns the vertex at the given position (index).
-   * 
-   * @param index the index of the vertex 0 <= index < getVertexCount( )
-   * @param vertex output vertex object, must be initialized
-   */
+  /// Returns the vertex at the given position (index).
+  ///
+  /// @param index the index of the vertex 0 <= index < getVertexCount( )
+  /// @param vertex output vertex object, must be initialized
   Vector2 getVertex(int index) {
     assert(index >= 0 && index < _vertices.length);
     return _vertices[index].clone();
@@ -178,12 +171,10 @@ class ChainShape extends Shape {
     return _vertices.length;
   }
 
-  /**
-   * Create a loop. This automatically adjusts connectivity.
-   * 
-   * @param vertices an array of vertices, these are copied
-   * @param count the vertex count
-   */
+  /// Create a loop. This automatically adjusts connectivity.
+  ///
+  /// @param vertices an array of vertices, these are copied
+  /// @param count the vertex count
   void createLoop(final List<Vector2> vertices, int count) {
     assert(_vertices == null && _count == 0);
     assert(count >= 3);
@@ -208,12 +199,10 @@ class ChainShape extends Shape {
     _hasNextVertex = true;
   }
 
-  /**
-   * Create a chain with isolated end vertices.
-   * 
-   * @param vertices an array of vertices, these are copied
-   * @param count the vertex count
-   */
+  /// Create a chain with isolated end vertices.
+  ///
+  /// @param vertices an array of vertices, these are copied
+  /// @param count the vertex count
   void createChain(final List<Vector2> vertices, int count) {
     assert(_vertices == null && _count == 0);
     assert(count >= 2);
@@ -238,21 +227,13 @@ class ChainShape extends Shape {
     _nextVertex.setZero();
   }
 
-  /**
-   * Establish connectivity to a vertex that precedes the first vertex. Don't call this for loops.
-   * 
-   * @param prevVertex
-   */
+  /// Establish connectivity to a vertex that precedes the first vertex. Don't call this for loops.
   void setPrevVertex(final Vector2 prevVertex) {
     _prevVertex.setFrom(prevVertex);
     _hasPrevVertex = true;
   }
 
-  /**
-   * Establish connectivity to a vertex that follows the last vertex. Don't call this for loops.
-   * 
-   * @param nextVertex
-   */
+  /// Establish connectivity to a vertex that follows the last vertex. Don't call this for loops.
   void setNextVertex(final Vector2 nextVertex) {
     _nextVertex.setFrom(nextVertex);
     _hasNextVertex = true;

--- a/lib/src/collision/shapes/circle_shape.dart
+++ b/lib/src/collision/shapes/circle_shape.dart
@@ -169,7 +169,7 @@ class CircleShape extends Shape {
   }
 
   void computeMass(final MassData massData, final double density) {
-    massData.mass = density * Math.PI * radius * radius;
+    massData.mass = density * Math.pi * radius * radius;
     massData.center.x = p.x;
     massData.center.y = p.y;
 

--- a/lib/src/collision/shapes/circle_shape.dart
+++ b/lib/src/collision/shapes/circle_shape.dart
@@ -28,14 +28,14 @@ part of box2d;
  * A circle shape.
  */
 class CircleShape extends Shape {
-  final Vector2 p = new Vector2.zero();
+  final Vector2 p = Vector2.zero();
 
   CircleShape() : super(ShapeType.CIRCLE) {
     radius = 0.0;
   }
 
   Shape clone() {
-    CircleShape shape = new CircleShape();
+    CircleShape shape = CircleShape();
     shape.p.x = p.x;
     shape.p.y = p.y;
     shape.radius = radius;

--- a/lib/src/collision/shapes/circle_shape.dart
+++ b/lib/src/collision/shapes/circle_shape.dart
@@ -1,32 +1,30 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A circle shape.
- */
+/// A circle shape.
 class CircleShape extends Shape {
   final Vector2 p = Vector2.zero();
 
@@ -44,46 +42,22 @@ class CircleShape extends Shape {
 
   int getChildCount() => 1;
 
-  /**
-   * Get the supporting vertex index in the given direction.
-   *
-   * @param d
-   * @return
-   */
+  /// Get the supporting vertex index in the given direction.
   int getSupport(final Vector2 d) => 0;
 
-  /**
-   * Get the supporting vertex in the given direction.
-   *
-   * @param d
-   * @return
-   */
+  /// Get the supporting vertex in the given direction.
   Vector2 getSupportVertex(final Vector2 d) => p;
 
-  /**
-   * Get the vertex count.
-   *
-   * @return
-   */
+  /// Get the vertex count.
   int getVertexCount() => 1;
 
-  /**
-   * Get a vertex by index.
-   *
-   * @param index
-   * @return
-   */
+  /// Get a vertex by index.
   Vector2 getVertex(final int index) {
     assert(index == 0);
     return p;
   }
 
   bool testPoint(final Transform transform, final Vector2 p) {
-    // Rot.mulToOutUnsafe(transform.q, _p, center);
-    // center.addLocal(transform.p);
-    //
-    // final Vec2 d = center.subLocal(p).negateLocal();
-    // return Vec2.dot(d, d) <= _radius * _radius;
     final Rot q = transform.q;
     final Vector2 tp = transform.p;
     double centerx = -(q.c * p.x - q.s * p.y + tp.x - p.x);
@@ -174,7 +148,6 @@ class CircleShape extends Shape {
     massData.center.y = p.y;
 
     // inertia about the local origin
-    // massData.I = massData.mass * (0.5f * _radius * _radius + Vec2.dot(_p, _p));
     massData.I =
         massData.mass * (0.5 * radius * radius + (p.x * p.x + p.y * p.y));
   }

--- a/lib/src/collision/shapes/edge_shape.dart
+++ b/lib/src/collision/shapes/edge_shape.dart
@@ -34,20 +34,20 @@ class EdgeShape extends Shape {
   /**
    * edge vertex 1
    */
-  final Vector2 vertex1 = new Vector2.zero();
+  final Vector2 vertex1 = Vector2.zero();
   /**
    * edge vertex 2
    */
-  final Vector2 vertex2 = new Vector2.zero();
+  final Vector2 vertex2 = Vector2.zero();
 
   /**
    * optional adjacent vertex 1. Used for smooth collision
    */
-  final Vector2 vertex0 = new Vector2.zero();
+  final Vector2 vertex0 = Vector2.zero();
   /**
    * optional adjacent vertex 2. Used for smooth collision
    */
-  final Vector2 vertex3 = new Vector2.zero();
+  final Vector2 vertex3 = Vector2.zero();
   bool hasVertex0 = false, hasVertex3 = false;
 
   EdgeShape() : super(ShapeType.EDGE) {
@@ -69,7 +69,7 @@ class EdgeShape extends Shape {
   }
 
   // for pooling
-  final Vector2 normal = new Vector2.zero();
+  final Vector2 normal = Vector2.zero();
 
   double computeDistanceToOut(
       Transform xf, Vector2 p, int childIndex, Vector2 normalOut) {
@@ -227,7 +227,7 @@ class EdgeShape extends Shape {
   }
 
   Shape clone() {
-    EdgeShape edge = new EdgeShape();
+    EdgeShape edge = EdgeShape();
     edge.radius = this.radius;
     edge.hasVertex0 = this.hasVertex0;
     edge.hasVertex3 = this.hasVertex3;

--- a/lib/src/collision/shapes/edge_shape.dart
+++ b/lib/src/collision/shapes/edge_shape.dart
@@ -1,52 +1,42 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A line segment (edge) shape. These can be connected in chains or loops to other edge shapes. The
- * connectivity information is used to ensure correct contact normals.
- *
- * @author Daniel
- */
+/// A line segment (edge) shape. These can be connected in chains or loops to other edge shapes. The
+/// connectivity information is used to ensure correct contact normals.
 class EdgeShape extends Shape {
-  /**
-   * edge vertex 1
-   */
+  /// edge vertex 1
   final Vector2 vertex1 = Vector2.zero();
-  /**
-   * edge vertex 2
-   */
+
+  /// edge vertex 2
   final Vector2 vertex2 = Vector2.zero();
 
-  /**
-   * optional adjacent vertex 1. Used for smooth collision
-   */
+  /// optional adjacent vertex 1. Used for smooth collision
   final Vector2 vertex0 = Vector2.zero();
-  /**
-   * optional adjacent vertex 2. Used for smooth collision
-   */
+
+  /// optional adjacent vertex 2. Used for smooth collision
   final Vector2 vertex3 = Vector2.zero();
   bool hasVertex0 = false, hasVertex3 = false;
 

--- a/lib/src/collision/shapes/mass_data.dart
+++ b/lib/src/collision/shapes/mass_data.dart
@@ -36,7 +36,7 @@ class MassData {
   /**
    * Blank mass data
    */
-  MassData() : this.center = new Vector2.zero();
+  MassData() : this.center = Vector2.zero();
 
   /**
    * Copies from the given mass data
@@ -57,6 +57,6 @@ class MassData {
 
   /** Return a copy of this object. */
   MassData clone() {
-    return new MassData.copy(this);
+    return MassData.copy(this);
   }
 }

--- a/lib/src/collision/shapes/mass_data.dart
+++ b/lib/src/collision/shapes/mass_data.dart
@@ -24,26 +24,23 @@
 
 part of box2d;
 
-/** This holds the mass data computed for a shape. */
+/// This holds the mass data computed for a shape.
 class MassData {
-  /** The mass of the shape, usually in kilograms. */
+  /// The mass of the shape, usually in kilograms.
   double mass = 0.0;
-  /** The position of the shape's centroid relative to the shape's origin. */
+
+  /// The position of the shape's centroid relative to the shape's origin.
   final Vector2 center;
-  /** The rotational inertia of the shape about the local origin. */
+
+  /// The rotational inertia of the shape about the local origin.
   double I = 0.0;
 
-  /**
-   * Blank mass data
-   */
+  /// Blank mass data
   MassData() : this.center = Vector2.zero();
 
-  /**
-   * Copies from the given mass data
-   * 
-   * @param md
-   *            mass data to copy from
-   */
+  /// Copies from the given mass data
+  ///
+  /// @param md mass data to copy from
   MassData.copy(MassData md)
       : mass = md.mass,
         center = md.center.clone(),
@@ -55,7 +52,7 @@ class MassData {
     center.setFrom(md.center);
   }
 
-  /** Return a copy of this object. */
+  /// Return a copy of this object.
   MassData clone() {
     return MassData.copy(this);
   }

--- a/lib/src/collision/shapes/polygon_shape.dart
+++ b/lib/src/collision/shapes/polygon_shape.dart
@@ -391,7 +391,7 @@ class PolygonShape extends Shape {
     double pLocalx = xfqc * tx + xfqs * ty;
     double pLocaly = -xfqs * tx + xfqc * ty;
 
-    double maxDistance = -double.MAX_FINITE;
+    double maxDistance = -double.maxFinite;
     double normalForMaxDistanceX = pLocalx;
     double normalForMaxDistanceY = pLocaly;
 

--- a/lib/src/collision/shapes/polygon_shape.dart
+++ b/lib/src/collision/shapes/polygon_shape.dart
@@ -35,19 +35,19 @@ class PolygonShape extends Shape {
   /**
    * Local position of the shape centroid in parent body frame.
    */
-  final Vector2 centroid = new Vector2.zero();
+  final Vector2 centroid = Vector2.zero();
 
   /**
    * The vertices of the shape. Note: use getVertexCount(), not _vertices.length, to get number of
    * active vertices.
    */
-  final List<Vector2> vertices = new List<Vector2>(Settings.maxPolygonVertices);
+  final List<Vector2> vertices = List<Vector2>(Settings.maxPolygonVertices);
 
   /**
    * The normals of the shape. Note: use getVertexCount(), not _normals.length, to get number of
    * active normals.
    */
-  final List<Vector2> normals = new List<Vector2>(Settings.maxPolygonVertices);
+  final List<Vector2> normals = List<Vector2>(Settings.maxPolygonVertices);
 
   /**
    * Number of active vertices in the shape.
@@ -55,25 +55,25 @@ class PolygonShape extends Shape {
   int count = 0;
 
   // pooling
-  final Vector2 _pool1 = new Vector2.zero();
-  final Vector2 _pool2 = new Vector2.zero();
-  final Vector2 _pool3 = new Vector2.zero();
-  final Vector2 _pool4 = new Vector2.zero();
-  Transform _poolt1 = new Transform.zero();
+  final Vector2 _pool1 = Vector2.zero();
+  final Vector2 _pool2 = Vector2.zero();
+  final Vector2 _pool3 = Vector2.zero();
+  final Vector2 _pool4 = Vector2.zero();
+  Transform _poolt1 = Transform.zero();
 
   PolygonShape() : super(ShapeType.POLYGON) {
     for (int i = 0; i < vertices.length; i++) {
-      vertices[i] = new Vector2.zero();
+      vertices[i] = Vector2.zero();
     }
 
     for (int i = 0; i < normals.length; i++) {
-      normals[i] = new Vector2.zero();
+      normals[i] = Vector2.zero();
     }
     radius = Settings.polygonRadius;
   }
 
   Shape clone() {
-    PolygonShape shape = new PolygonShape();
+    PolygonShape shape = PolygonShape();
     shape.centroid.setFrom(this.centroid);
     for (int i = 0; i < shape.normals.length; i++) {
       shape.normals[i].setFrom(normals[i]);
@@ -115,7 +115,7 @@ class PolygonShape extends Shape {
     // Perform welding and copy vertices into local buffer.
     List<Vector2> ps = (vecPool != null)
         ? vecPool.get(Settings.maxPolygonVertices)
-        : new List<Vector2>(Settings.maxPolygonVertices);
+        : List<Vector2>(Settings.maxPolygonVertices);
     int tempCount = 0;
     for (int i = 0; i < n; ++i) {
       Vector2 v = verts[i];
@@ -200,7 +200,7 @@ class PolygonShape extends Shape {
     // Copy vertices.
     for (int i = 0; i < count; ++i) {
       if (vertices[i] == null) {
-        vertices[i] = new Vector2.zero();
+        vertices[i] = Vector2.zero();
       }
       vertices[i].setFrom(ps[hull[i]]);
     }

--- a/lib/src/collision/shapes/polygon_shape.dart
+++ b/lib/src/collision/shapes/polygon_shape.dart
@@ -1,57 +1,47 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A convex polygon shape. Polygons have a maximum number of vertices equal to _maxPolygonVertices.
- * In most cases you should not need many vertices for a convex polygon.
- */
+/// A convex polygon shape. Polygons have a maximum number of vertices equal to _maxPolygonVertices.
+/// In most cases you should not need many vertices for a convex polygon.
 class PolygonShape extends Shape {
-  /** Dump lots of debug information. */
+  /// Dump lots of debug information.
   static const bool _debug = false;
 
-  /**
-   * Local position of the shape centroid in parent body frame.
-   */
+  /// Local position of the shape centroid in parent body frame.
   final Vector2 centroid = Vector2.zero();
 
-  /**
-   * The vertices of the shape. Note: use getVertexCount(), not _vertices.length, to get number of
-   * active vertices.
-   */
+  /// The vertices of the shape. Note: use getVertexCount(), not _vertices.length, to get number of
+  /// active vertices.
   final List<Vector2> vertices = List<Vector2>(Settings.maxPolygonVertices);
 
-  /**
-   * The normals of the shape. Note: use getVertexCount(), not _normals.length, to get number of
-   * active normals.
-   */
+  /// The normals of the shape. Note: use getVertexCount(), not _normals.length, to get number of
+  /// active normals.
   final List<Vector2> normals = List<Vector2>(Settings.maxPolygonVertices);
 
-  /**
-   * Number of active vertices in the shape.
-   */
+  /// Number of active vertices in the shape.
   int count = 0;
 
   // pooling
@@ -84,24 +74,18 @@ class PolygonShape extends Shape {
     return shape;
   }
 
-  /**
-   * Create a convex hull from the given array of points. The count must be in the range [3,
-   * Settings.maxPolygonVertices].
-   *
-   * @warning the points may be re-ordered, even if they form a convex polygon.
-   * @warning collinear points are removed.
-   */
+  /// Create a convex hull from the given array of points. The count must be in the range [3,
+  /// Settings.maxPolygonVertices].
+  /// @warning the points may be re-ordered, even if they form a convex polygon.
+  /// @warning collinear points are removed.
   void set(final List<Vector2> vertices, final int count) {
     setWithPools(vertices, count, null, null);
   }
 
-  /**
-   * Create a convex hull from the given array of points. The count must be in the range [3,
-   * Settings.maxPolygonVertices]. This method takes an arraypool for pooling.
-   *
-   * @warning the points may be re-ordered, even if they form a convex polygon.
-   * @warning collinear points are removed.
-   */
+  /// Create a convex hull from the given array of points. The count must be in the range [3,
+  /// Settings.maxPolygonVertices]. This method takes an arraypool for pooling.
+  /// @warning the points may be re-ordered, even if they form a convex polygon.
+  /// @warning collinear points are removed.
   void setWithPools(final List<Vector2> verts, final int num,
       final Vec2Array vecPool, final IntArray intPool) {
     assert(3 <= num && num <= Settings.maxPolygonVertices);
@@ -224,12 +208,10 @@ class PolygonShape extends Shape {
     computeCentroidToOut(vertices, count, centroid);
   }
 
-  /**
-   * Build vertices to represent an axis-aligned box.
-   *
-   * @param hx the half-width.
-   * @param hy the half-height.
-   */
+  /// Build vertices to represent an axis-aligned box.
+  ///
+  /// @param hx the half-width.
+  /// @param hy the half-height.
   void setAsBoxXY(final double hx, final double hy) {
     count = 4;
     vertices[0].setValues(-hx, -hy);
@@ -243,14 +225,12 @@ class PolygonShape extends Shape {
     centroid.setZero();
   }
 
-  /**
-   * Build vertices to represent an oriented box.
-   *
-   * @param hx the half-width.
-   * @param hy the half-height.
-   * @param center the center of the box in local coordinates.
-   * @param angle the rotation of the box in local coordinates.
-   */
+  /// Build vertices to represent an oriented box.
+  ///
+  /// @param hx the half-width.
+  /// @param hy the half-height.
+  /// @param center the center of the box in local coordinates.
+  /// @param angle the rotation of the box in local coordinates.
   void setAsBox(final double hx, final double hy, final Vector2 center,
       final double angle) {
     count = 4;
@@ -275,9 +255,7 @@ class PolygonShape extends Shape {
     }
   }
 
-  /**
-   * Set this as a single edge.
-   */
+  /// Set this as a single edge.
   void setAsEdge(Vector2 v1, Vector2 v2) {
     count = 2;
     vertices[0].setFrom(v1);
@@ -362,21 +340,12 @@ class PolygonShape extends Shape {
     upper.y += radius;
   }
 
-  /**
-   * Get the vertex count.
-   *
-   * @return
-   */
+  /// Get the vertex count.
   int getVertexCount() {
     return count;
   }
 
-  /**
-   * Get a vertex by index.
-   *
-   * @param index
-   * @return
-   */
+  /// Get a vertex by index.
   Vector2 getVertex(final int index) {
     assert(0 <= index && index < count);
     return vertices[index];
@@ -656,11 +625,7 @@ class PolygonShape extends Shape {
     massData.I += massData.mass * (massData.center.dot(massData.center));
   }
 
-  /**
-   * Validate convexity. This is a very time consuming operation.
-   *
-   * @return
-   */
+  /// Validate convexity. This is a very time consuming operation.
   bool validate() {
     for (int i = 0; i < count; ++i) {
       int i1 = i;
@@ -688,12 +653,12 @@ class PolygonShape extends Shape {
     return true;
   }
 
-  /** Get the centroid and apply the supplied transform. */
+  /// Get the centroid and apply the supplied transform.
   Vector2 applyToCentroid(final Transform xf) {
     return Transform.mulVec2(xf, centroid);
   }
 
-  /** Get the centroid and apply the supplied transform. */
+  /// Get the centroid and apply the supplied transform.
   Vector2 centroidToOut(final Transform xf, final Vector2 out) {
     Transform.mulToOutUnsafeVec2(xf, centroid, out);
     return out;

--- a/lib/src/collision/shapes/shape.dart
+++ b/lib/src/collision/shapes/shape.dart
@@ -1,93 +1,77 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A shape is used for collision detection. You can create a shape however you like. Shapes used for
- * simulation in World are created automatically when a Fixture is created. Shapes may encapsulate a
- * one or more child shapes.
- */
+/// A shape is used for collision detection. You can create a shape however you like. Shapes used for
+/// simulation in World are created automatically when a Fixture is created. Shapes may encapsulate a
+/// one or more child shapes.
 abstract class Shape {
   final ShapeType shapeType;
   double radius = 0.0;
 
   Shape(this.shapeType);
 
-  /**
-   * Get the number of child primitives
-   *
-   * @return
-   */
+  /// Get the number of child primitives
   int getChildCount();
 
-  /**
-   * Test a point for containment in this shape. This only works for convex shapes.
-   *
-   * @param xf the shape world transform.
-   * @param p a point in world coordinates.
-   */
+  /// Test a point for containment in this shape. This only works for convex shapes.
+  ///
+  /// @param xf the shape world transform.
+  /// @param p a point in world coordinates.
   bool testPoint(final Transform xf, final Vector2 p);
 
-  /**
-   * Cast a ray against a child shape.
-   *
-   * @param argOutput the ray-cast results.
-   * @param argInput the ray-cast input parameters.
-   * @param argTransform the transform to be applied to the shape.
-   * @param argChildIndex the child shape index
-   * @return if hit
-   */
+  /// Cast a ray against a child shape.
+  ///
+  /// @param argOutput the ray-cast results.
+  /// @param argInput the ray-cast input parameters.
+  /// @param argTransform the transform to be applied to the shape.
+  /// @param argChildIndex the child shape index
+  /// @return if hit
   bool raycast(RayCastOutput output, RayCastInput input, Transform transform,
       int childIndex);
 
-  /**
-   * Given a transform, compute the associated axis aligned bounding box for a child shape.
-   *
-   * @param argAabb returns the axis aligned box.
-   * @param argXf the world transform of the shape.
-   */
+  /// Given a transform, compute the associated axis aligned bounding box for a child shape.
+  ///
+  /// @param argAabb returns the axis aligned box.
+  /// @param argXf the world transform of the shape.
   void computeAABB(final AABB aabb, final Transform xf, int childIndex);
 
-  /**
-   * Compute the mass properties of this shape using its dimensions and density. The inertia tensor
-   * is computed about the local origin.
-   *
-   * @param massData returns the mass data for this shape.
-   * @param density the density in kilograms per meter squared.
-   */
+  /// Compute the mass properties of this shape using its dimensions and density. The inertia tensor
+  /// is computed about the local origin.
+  ///
+  /// @param massData returns the mass data for this shape.
+  /// @param density the density in kilograms per meter squared.
   void computeMass(final MassData massData, final double density);
 
-  /**
-   * Compute the distance from the current shape to the specified point. This only works for convex
-   * shapes.
-   *
-   * @param xf the shape world transform.
-   * @param p a point in world coordinates.
-   * @param normalOut returns the direction in which the distance increases.
-   * @return distance returns the distance from the current shape.
-   */
+  /// Compute the distance from the current shape to the specified point. This only works for convex
+  /// shapes.
+  ///
+  /// @param xf the shape world transform.
+  /// @param p a point in world coordinates.
+  /// @param normalOut returns the direction in which the distance increases.
+  /// @return distance returns the distance from the current shape.
   double computeDistanceToOut(
       Transform xf, Vector2 p, int childIndex, Vector2 normalOut);
 

--- a/lib/src/collision/shapes/shape_type.dart
+++ b/lib/src/collision/shapes/shape_type.dart
@@ -1,7 +1,4 @@
 part of box2d;
 
-/**
- * Types of shapes
- * @author Daniel
- */
+/// Types of shapes
 enum ShapeType { CIRCLE, EDGE, POLYGON, CHAIN }

--- a/lib/src/collision/time_of_impact.dart
+++ b/lib/src/collision/time_of_impact.dart
@@ -1,63 +1,50 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * Input parameters for TOI
- *
- * @author Daniel Murphy
- */
+/// Input parameters for TOI
 class TOIInput {
   final DistanceProxy proxyA = new DistanceProxy();
   final DistanceProxy proxyB = new DistanceProxy();
   final Sweep sweepA = new Sweep();
   final Sweep sweepB = new Sweep();
-  /**
-   * defines sweep interval [0, tMax]
-   */
+
+  /// defines sweep interval [0, tMax]
   double tMax = 0.0;
 }
 
 enum TOIOutputState { UNKNOWN, FAILED, OVERLAPPED, TOUCHING, SEPARATED }
 
-/**
- * Output parameters for TimeOfImpact
- *
- * @author daniel
- */
+/// Output parameters for TimeOfImpact
 class TOIOutput {
   TOIOutputState state = TOIOutputState.UNKNOWN;
   double t = 0.0;
 }
 
-/**
- * Class used for computing the time of impact. This class should not be constructed usually, just
- * retrieve from the {@link SingletonPool#getTOI()}.
- *
- * @author daniel
- */
+/// Class used for computing the time of impact. This class should not be constructed usually, just
+/// retrieve from the {@link SingletonPool#getTOI()}.
 class TimeOfImpact {
   static const int MAX_ITERATIONS = 20;
   static const int MAX_ROOT_ITERATIONS = 50;
@@ -83,15 +70,10 @@ class TimeOfImpact {
 
   TimeOfImpact(this._pool);
 
-  /**
-   * Compute the upper bound on time before two shapes penetrate. Time is represented as a fraction
-   * between [0,tMax]. This uses a swept separating axis and may miss some intermediate,
-   * non-tunneling collision. If you change the time interval, you should call this function again.
-   * Note: use Distance to compute the contact point and normal at the time of impact.
-   *
-   * @param output
-   * @param input
-   */
+  /// Compute the upper bound on time before two shapes penetrate. Time is represented as a fraction
+  /// between [0,tMax]. This uses a swept separating axis and may miss some intermediate,
+  /// non-tunneling collision. If you change the time interval, you should call this function again.
+  /// Note: use Distance to compute the contact point and normal at the time of impact.
   void timeOfImpact(TOIOutput output, TOIInput input) {
     // CCD via the local separating axis method. This seeks progression
     // by computing the largest time at which separation is maintained.

--- a/lib/src/collision/world_manifold.dart
+++ b/lib/src/collision/world_manifold.dart
@@ -33,26 +33,26 @@ class WorldManifold {
   /**
    * World vector pointing from A to B
    */
-  final Vector2 normal = new Vector2.zero();
+  final Vector2 normal = Vector2.zero();
 
   /**
    * World contact point (point of intersection)
    */
-  final List<Vector2> points = new List<Vector2>(Settings.maxManifoldPoints);
+  final List<Vector2> points = List<Vector2>(Settings.maxManifoldPoints);
 
   /**
    * A negative value indicates overlap, in meters.
    */
-  final Float64List separations = new Float64List(Settings.maxManifoldPoints);
+  final Float64List separations = Float64List(Settings.maxManifoldPoints);
 
   WorldManifold() {
     for (int i = 0; i < Settings.maxManifoldPoints; i++) {
-      points[i] = new Vector2.zero();
+      points[i] = Vector2.zero();
     }
   }
 
-  final Vector2 _pool3 = new Vector2.zero();
-  final Vector2 _pool4 = new Vector2.zero();
+  final Vector2 _pool3 = Vector2.zero();
+  final Vector2 _pool4 = Vector2.zero();
 
   void initialize(final Manifold manifold, final Transform xfA, double radiusA,
       final Transform xfB, double radiusB) {

--- a/lib/src/collision/world_manifold.dart
+++ b/lib/src/collision/world_manifold.dart
@@ -24,25 +24,15 @@
 
 part of box2d;
 
-/**
- * This is used to compute the current state of a contact manifold.
- * 
- * @author daniel
- */
+/// This is used to compute the current state of a contact manifold.
 class WorldManifold {
-  /**
-   * World vector pointing from A to B
-   */
+  /// World vector pointing from A to B
   final Vector2 normal = Vector2.zero();
 
-  /**
-   * World contact point (point of intersection)
-   */
+  /// World contact point (point of intersection)
   final List<Vector2> points = List<Vector2>(Settings.maxManifoldPoints);
 
-  /**
-   * A negative value indicates overlap, in meters.
-   */
+  /// A negative value indicates overlap, in meters.
   final Float64List separations = Float64List(Settings.maxManifoldPoints);
 
   WorldManifold() {

--- a/lib/src/common/canvas_viewport_transform.dart
+++ b/lib/src/common/canvas_viewport_transform.dart
@@ -26,7 +26,7 @@ library box2d.common.canvas_viewport_transform;
 
 import 'dart:html';
 
-import 'package:box2d/box2d.dart';
+import 'package:box2d_flame/box2d.dart';
 
 /**
  * Transform for drawing using a canvas context. Y-flip is permenantly set

--- a/lib/src/common/canvas_viewport_transform.dart
+++ b/lib/src/common/canvas_viewport_transform.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015,  Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library box2d.common.canvas_viewport_transform;
 
@@ -28,25 +28,19 @@ import 'dart:html';
 
 import 'package:box2d_flame/box2d.dart';
 
-/**
- * Transform for drawing using a canvas context. Y-flip is permenantly set
- * to true.
- */
+/// Transform for drawing using a canvas context. Y-flip is permenantly set
+/// to true.
 class CanvasViewportTransform extends ViewportTransform {
   static const double DEFAULT_DRAWING_SCALE = 20.0;
 
-  /**
-   * Constructs a new viewport transform with the default scale.
-   */
+  /// Constructs a new viewport transform with the default scale.
   CanvasViewportTransform(Vector2 _extents, Vector2 _center)
       : super(_extents, _center, DEFAULT_DRAWING_SCALE) {
     yFlip = true;
   }
 
-  /**
-   * Sets the rendering context such that all drawing commands given in terms
-   * of the world coordinate system will display correctly on the canvas screen.
-   */
+  /// Sets the rendering context such that all drawing commands given in terms
+  /// of the world coordinate system will display correctly on the canvas screen.
   void updateTransformation(CanvasRenderingContext2D ctx) {
     // Clear all previous transformation.
     ctx.setTransform(1, 0, 0, 1, 0, 0);

--- a/lib/src/common/color3i.dart
+++ b/lib/src/common/color3i.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d.common;
 

--- a/lib/src/common/raycast_result.dart
+++ b/lib/src/common/raycast_result.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d.common;
 

--- a/lib/src/common/rot.dart
+++ b/lib/src/common/rot.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d.common;
 

--- a/lib/src/common/sweep.dart
+++ b/lib/src/common/sweep.dart
@@ -1,43 +1,43 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d.common;
 
-/**
- * This describes the motion of a body/shape for TOI computation. Shapes are defined with respect to
- * the body origin, which may not coincide with the center of mass. However, to support dynamics we
- * must interpolate the center of mass position.
- */
+/// This describes the motion of a body/shape for TOI computation. Shapes are defined with respect to
+/// the body origin, which may not coincide with the center of mass. However, to support dynamics we
+/// must interpolate the center of mass position.
 class Sweep {
-  /** Local center of mass position */
+  /// Local center of mass position
   final Vector2 localCenter = new Vector2.zero();
-  /** Center world positions */
+
+  /// Center world positions
   final Vector2 c0 = new Vector2.zero(), c = new Vector2.zero();
-  /** World angles */
+
+  /// World angles
   double a0 = 0.0, a = 0.0;
 
-  /** Fraction of the current time step in the range [0,1] c0 and a0 are the positions at alpha0. */
+  /// Fraction of the current time step in the range [0,1] c0 and a0 are the positions at alpha0.
   double alpha0 = 0.0;
 
   String toString() {
@@ -64,12 +64,10 @@ class Sweep {
     return this;
   }
 
-  /**
-   * Get the interpolated transform at a specific time.
-   *
-   * @param xf the result is placed here - must not be null
-   * @param t the normalized time in [0,1].
-   */
+  /// Get the interpolated transform at a specific time.
+  ///
+  /// @param xf the result is placed here - must not be null
+  /// @param t the normalized time in [0,1].
   void getTransform(final Transform xf, final double beta) {
     assert(xf != null);
     // xf->p = (1.0f - beta) * c0 + beta * c;
@@ -87,11 +85,9 @@ class Sweep {
     xf.p.y -= q.s * localCenter.x + q.c * localCenter.y;
   }
 
-  /**
-   * Advance the sweep forward, yielding a new initial state.
-   *
-   * @param alpha the new initial time.
-   */
+  /// Advance the sweep forward, yielding a new initial state.
+  ///
+  /// @param alpha the new initial time.
   void advance(double alpha) {
     assert(alpha0 < 1.0);
     // float32 beta = (alpha - alpha0) / (1.0f - alpha0);

--- a/lib/src/common/timer.dart
+++ b/lib/src/common/timer.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d.common;
 

--- a/lib/src/common/transform.dart
+++ b/lib/src/common/transform.dart
@@ -109,7 +109,6 @@ class Transform {
 
   static void mulTransToOutUnsafeVec2(
       final Transform T, final Vector2 v, final Vector2 out) {
-    assert(v != out);
     final double px = v.x - T.p.x;
     final double py = v.y - T.p.y;
     out.x = (T.q.c * px + T.q.s * py);

--- a/lib/src/common/transform.dart
+++ b/lib/src/common/transform.dart
@@ -1,74 +1,67 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d.common;
 
-/**
- * A transform contains translation and rotation. It is used to represent the position and
- * orientation of rigid frames.
- */
+/// A transform contains translation and rotation. It is used to represent the position and
+/// orientation of rigid frames.
 class Transform {
-  /** The translation caused by the transform */
+  /// The translation caused by the transform
   final Vector2 p;
 
-  /** A matrix representing a rotation */
+  /// A matrix representing a rotation
   final Rot q;
 
-  /** The default constructor. */
+  /// The default constructor.
   Transform.zero()
       : p = new Vector2.zero(),
         q = new Rot();
 
-  /** Initialize as a copy of another transform. */
+  /// Initialize as a copy of another transform.
   Transform.clone(final Transform xf)
       : p = xf.p.clone(),
         q = xf.q.clone();
 
-  /** Initialize using a position vector and a rotation matrix. */
+  /// Initialize using a position vector and a rotation matrix.
   Transform.from(final Vector2 _position, final Rot _R)
       : p = _position.clone(),
         q = _R.clone();
 
-  /** Set this to equal another transform. */
+  /// Set this to equal another transform.
   Transform set(final Transform xf) {
     p.setFrom(xf.p);
     q.set(xf.q);
     return this;
   }
 
-  /**
-   * Set this based on the position and angle.
-   *
-   * @param p
-   * @param angle
-   */
+  /// Set this based on the position and angle.
   void setVec2Angle(Vector2 p, double angle) {
     p.setFrom(p);
     q.setAngle(angle);
   }
 
-  /** Set this to the identity transform. */
+  /// Set this to the identity transform.
   void setIdentity() {
     p.setZero();
     q.setIdentity();

--- a/lib/src/common/viewport_transform.dart
+++ b/lib/src/common/viewport_transform.dart
@@ -86,8 +86,8 @@ class ViewportTransform {
     double gridCorrectedX = (argWorld.x * scale) + extents.x;
     double gridCorrectedY = extents.y - (argWorld.y * scale);
 
-    return Vector2(gridCorrectedX + translation.x,
-        gridCorrectedY + -translation.y);
+    return Vector2(
+        gridCorrectedX + translation.x, gridCorrectedY + -translation.y);
   }
 
   /**

--- a/lib/src/common/viewport_transform.dart
+++ b/lib/src/common/viewport_transform.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d.common;
 
@@ -29,44 +29,32 @@ class ViewportTransform {
       : extents = new Vector2.copy(e),
         center = new Vector2.copy(c);
 
-  /**
-   * if we flip the y axis when transforming.
-   */
+  /// if we flip the y axis when transforming.
   bool yFlip;
 
-  /**
-   * This is the half-width and half-height.
-   * This should be the actual half-width and
-   * half-height, not anything transformed or scaled.
-   */
+  /// This is the half-width and half-height.
+  /// This should be the actual half-width and
+  /// half-height, not anything transformed or scaled.
   Vector2 extents;
 
-  /**
-   * Returns the scaling factor used in converting from world sizes to rendering
-   * sizes.
-   */
+  /// Returns the scaling factor used in converting from world sizes to rendering
+  /// sizes.
   double scale;
 
-  /**
-   * center of the viewport.
-   */
+  /// center of the viewport.
   Vector2 center;
 
-  /**
-   * Sets the transform's center to the given x and y coordinates,
-   * and using the given scale.
-   */
+  /// Sets the transform's center to the given x and y coordinates,
+  /// and using the given scale.
   void setCamera(double x, double y, double s) {
     center.setValues(x, y);
     scale = s;
   }
 
-  /**
-   * The current translation is the difference in canvas units between the
-   * actual center of the canvas and the currently specified center. For
-   * example, if the actual canvas center is (5, 5) but the current center is
-   * (6, 6), the translation is (1, 1).
-   */
+  /// The current translation is the difference in canvas units between the
+  /// actual center of the canvas and the currently specified center. For
+  /// example, if the actual canvas center is (5, 5) but the current center is
+  /// (6, 6), the translation is (1, 1).
   Vector2 get translation {
     Vector2 result = new Vector2.copy(extents);
     return result..sub(center);
@@ -77,9 +65,7 @@ class ViewportTransform {
     center.sub(translation);
   }
 
-  /**
-   * Takes the world coordinates and return the corresponding screen coordinates
-   */
+  /// Takes the world coordinates and return the corresponding screen coordinates
   Vector2 getWorldToScreen(Vector2 argWorld) {
     // Correct for canvas considering the upper-left corner, rather than the
     // center, to be the origin.
@@ -90,9 +76,7 @@ class ViewportTransform {
         gridCorrectedX + translation.x, gridCorrectedY + -translation.y);
   }
 
-  /**
-   * Takes the screen coordinates and return the corresponding world coordinates
-   */
+  /// Takes the screen coordinates and return the corresponding world coordinates
   Vector2 getScreenToWorld(Vector2 argScreen) {
     double translationCorrectedX = argScreen.x - translation.x;
     double translationCorrectedY = argScreen.y + translation.y;

--- a/lib/src/common/viewport_transform.dart
+++ b/lib/src/common/viewport_transform.dart
@@ -78,32 +78,27 @@ class ViewportTransform {
   }
 
   /**
-   * Takes the world coordinate (argWorld) puts the corresponding
-   * screen coordinate in argScreen.  It should be safe to give the
-   * same object as both parameters.
+   * Takes the world coordinates and return the corresponding screen coordinates
    */
-  void getWorldToScreen(Vector2 argWorld, Vector2 argScreen) {
+  Vector2 getWorldToScreen(Vector2 argWorld) {
     // Correct for canvas considering the upper-left corner, rather than the
     // center, to be the origin.
     double gridCorrectedX = (argWorld.x * scale) + extents.x;
     double gridCorrectedY = extents.y - (argWorld.y * scale);
 
-    Vector2 translationTemp = translation;
-    argScreen.setValues(gridCorrectedX + translationTemp.x,
-        gridCorrectedY + -translationTemp.y);
+    return Vector2(gridCorrectedX + translation.x,
+        gridCorrectedY + -translation.y);
   }
 
   /**
-   * Takes the screen coordinates (argScreen) and puts the
-   * corresponding world coordinates in argWorld. It should be safe
-   * to give the same object as both parameters.
+   * Takes the screen coordinates and return the corresponding world coordinates
    */
-  void getScreenToWorld(Vector2 argScreen, Vector2 argWorld) {
+  Vector2 getScreenToWorld(Vector2 argScreen) {
     double translationCorrectedX = argScreen.x - translation.x;
     double translationCorrectedY = argScreen.y + translation.y;
 
     double gridCorrectedX = (translationCorrectedX - extents.x) / scale;
     double gridCorrectedY = ((translationCorrectedY - extents.y) * -1) / scale;
-    argWorld.setValues(gridCorrectedX, gridCorrectedY);
+    return Vector2(gridCorrectedX, gridCorrectedY);
   }
 }

--- a/lib/src/dynamics/body.dart
+++ b/lib/src/dynamics/body.dart
@@ -47,22 +47,22 @@ class Body {
   /**
    * The body origin transform.
    */
-  final Transform _transform = new Transform.zero();
+  final Transform _transform = Transform.zero();
   /**
    * The previous transform for particle simulation
    */
-  final Transform _xf0 = new Transform.zero();
+  final Transform _xf0 = Transform.zero();
 
   /**
    * The swept motion for CCD
    */
-  final Sweep _sweep = new Sweep();
+  final Sweep _sweep = Sweep();
 
   /// the linear velocity of the center of mass
-  final Vector2 _linearVelocity = new Vector2.zero();
+  final Vector2 _linearVelocity = Vector2.zero();
   double _angularVelocity = 0.0;
 
-  final Vector2 _force = new Vector2.zero();
+  final Vector2 _force = Vector2.zero();
   double _torque = 0.0;
 
   final World world;
@@ -175,7 +175,7 @@ class Body {
       return null;
     }
 
-    Fixture fixture = new Fixture();
+    Fixture fixture = Fixture();
     fixture.create(this, def);
 
     if ((_flags & ACTIVE_FLAG) == ACTIVE_FLAG) {
@@ -201,7 +201,7 @@ class Body {
     return fixture;
   }
 
-  final FixtureDef _fixDef = new FixtureDef();
+  final FixtureDef _fixDef = FixtureDef();
 
   /**
    * Creates a fixture from a shape and attach it to this body. This is a convenience function. Use
@@ -604,7 +604,7 @@ class Body {
     world.getPool().pushVec2(2);
   }
 
-  final MassData _pmd = new MassData();
+  final MassData _pmd = MassData();
 
   /**
    * This resets the mass properties to the sum of the mass properties of the fixtures. This
@@ -693,7 +693,7 @@ class Body {
    * @return the same point expressed in world coordinates.
    */
   Vector2 getWorldPoint(Vector2 localPoint) {
-    Vector2 v = new Vector2.zero();
+    Vector2 v = Vector2.zero();
     getWorldPointToOut(localPoint, v);
     return v;
   }
@@ -709,7 +709,7 @@ class Body {
    * @return the same vector expressed in world coordinates.
    */
   Vector2 getWorldVector(Vector2 localVector) {
-    Vector2 out = new Vector2.zero();
+    Vector2 out = Vector2.zero();
     getWorldVectorToOut(localVector, out);
     return out;
   }
@@ -729,7 +729,7 @@ class Body {
    * @return the corresponding local point relative to the body's origin.
    */
   Vector2 getLocalPoint(Vector2 worldPoint) {
-    Vector2 out = new Vector2.zero();
+    Vector2 out = Vector2.zero();
     getLocalPointToOut(worldPoint, out);
     return out;
   }
@@ -745,7 +745,7 @@ class Body {
    * @return the corresponding local vector.
    */
   Vector2 getLocalVector(Vector2 worldVector) {
-    Vector2 out = new Vector2.zero();
+    Vector2 out = Vector2.zero();
     getLocalVectorToOut(worldVector, out);
     return out;
   }
@@ -765,7 +765,7 @@ class Body {
    * @return the world velocity of a point.
    */
   Vector2 getLinearVelocityFromWorldPoint(Vector2 worldPoint) {
-    Vector2 out = new Vector2.zero();
+    Vector2 out = Vector2.zero();
     getLinearVelocityFromWorldPointToOut(worldPoint, out);
     return out;
   }
@@ -784,7 +784,7 @@ class Body {
    * @return the world velocity of a point.
    */
   Vector2 getLinearVelocityFromLocalPoint(Vector2 localPoint) {
-    Vector2 out = new Vector2.zero();
+    Vector2 out = Vector2.zero();
     getLinearVelocityFromLocalPointToOut(localPoint, out);
     return out;
   }
@@ -1025,7 +1025,7 @@ class Body {
   }
 
   // djm pooling
-  final Transform _pxf = new Transform.zero();
+  final Transform _pxf = Transform.zero();
 
   void synchronizeFixtures() {
     final Transform xf1 = _pxf;

--- a/lib/src/dynamics/body.dart
+++ b/lib/src/dynamics/body.dart
@@ -1,34 +1,30 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A rigid body. These are created via World.createBody.
- *
- * @author Daniel Murphy
- */
+/// A rigid body. These are created via World.createBody.
 class Body {
   static const int ISLAND_FLAG = 0x0001;
   static const int AWAKE_FLAG = 0x0002;
@@ -44,18 +40,13 @@ class Body {
 
   int _islandIndex = 0;
 
-  /**
-   * The body origin transform.
-   */
+  /// The body origin transform.
   final Transform _transform = Transform.zero();
-  /**
-   * The previous transform for particle simulation
-   */
+
+  /// The previous transform for particle simulation
   final Transform _xf0 = Transform.zero();
 
-  /**
-   * The swept motion for CCD
-   */
+  /// The swept motion for CCD
   final Sweep _sweep = Sweep();
 
   /// the linear velocity of the center of mass
@@ -159,15 +150,13 @@ class Body {
     _fixtureCount = 0;
   }
 
-  /**
-   * Creates a fixture and attach it to this body. Use this function if you need to set some fixture
-   * parameters, like friction. Otherwise you can create the fixture directly from a shape. If the
-   * density is non-zero, this function automatically updates the mass of the body. Contacts are not
-   * created until the next time step.
-   *
-   * @param def the fixture definition.
-   * @warning This function is locked during callbacks.
-   */
+  /// Creates a fixture and attach it to this body. Use this function if you need to set some fixture
+  /// parameters, like friction. Otherwise you can create the fixture directly from a shape. If the
+  /// density is non-zero, this function automatically updates the mass of the body. Contacts are not
+  /// created until the next time step.
+  ///
+  /// @param def the fixture definition.
+  /// @warning This function is locked during callbacks.
   Fixture createFixtureFromFixtureDef(FixtureDef def) {
     assert(world.isLocked() == false);
 
@@ -203,15 +192,13 @@ class Body {
 
   final FixtureDef _fixDef = FixtureDef();
 
-  /**
-   * Creates a fixture from a shape and attach it to this body. This is a convenience function. Use
-   * FixtureDef if you need to set parameters like friction, restitution, user data, or filtering.
-   * If the density is non-zero, this function automatically updates the mass of the body.
-   *
-   * @param shape the shape to be cloned.
-   * @param density the shape density (set to zero for static bodies).
-   * @warning This function is locked during callbacks.
-   */
+  /// Creates a fixture from a shape and attach it to this body. This is a convenience function. Use
+  /// FixtureDef if you need to set parameters like friction, restitution, user data, or filtering.
+  /// If the density is non-zero, this function automatically updates the mass of the body.
+  ///
+  /// @param shape the shape to be cloned.
+  /// @param density the shape density (set to zero for static bodies).
+  /// @warning This function is locked during callbacks.
   Fixture createFixtureFromShape(Shape shape, [double density = 0.0]) {
     _fixDef.shape = shape;
     _fixDef.density = density;
@@ -219,15 +206,13 @@ class Body {
     return createFixtureFromFixtureDef(_fixDef);
   }
 
-  /**
-   * Destroy a fixture. This removes the fixture from the broad-phase and destroys all contacts
-   * associated with this fixture. This will automatically adjust the mass of the body if the body
-   * is dynamic and the fixture has positive density. All fixtures attached to a body are implicitly
-   * destroyed when the body is destroyed.
-   *
-   * @param fixture the fixture to be removed.
-   * @warning This function is locked during callbacks.
-   */
+  /// Destroy a fixture. This removes the fixture from the broad-phase and destroys all contacts
+  /// associated with this fixture. This will automatically adjust the mass of the body if the body
+  /// is dynamic and the fixture has positive density. All fixtures attached to a body are implicitly
+  /// destroyed when the body is destroyed.
+  ///
+  /// @param fixture the fixture to be removed.
+  /// @warning This function is locked during callbacks.
   void destroyFixture(Fixture fixture) {
     assert(world.isLocked() == false);
     if (world.isLocked() == true) {
@@ -293,14 +278,12 @@ class Body {
     resetMassData();
   }
 
-  /**
-   * Set the position of the body's origin and rotation. This breaks any contacts and wakes the
-   * other bodies. Manipulating a body's transform may cause non-physical behavior. Note: contacts
-   * are updated on the next call to World.step().
-   *
-   * @param position the world position of the body's local origin.
-   * @param angle the world rotation in radians.
-   */
+  /// Set the position of the body's origin and rotation. This breaks any contacts and wakes the
+  /// other bodies. Manipulating a body's transform may cause non-physical behavior. Note: contacts
+  /// are updated on the next call to World.step().
+  ///
+  /// @param position the world position of the body's local origin.
+  /// @param angle the world rotation in radians.
   void setTransform(Vector2 position, double angle) {
     assert(world.isLocked() == false);
     if (world.isLocked() == true) {
@@ -323,39 +306,29 @@ class Body {
     }
   }
 
-  /**
-   * Get the world body origin position. Do not modify.
-   *
-   * @return the world position of the body's origin.
-   */
+  /// Get the world body origin position. Do not modify.
+  ///
+  /// @return the world position of the body's origin.
   Vector2 get position => _transform.p;
 
-  /**
-   * Get the angle in radians.
-   *
-   * @return the current world rotation angle in radians.
-   */
+  /// Get the angle in radians.
+  ///
+  /// @return the current world rotation angle in radians.
   double getAngle() {
     return _sweep.a;
   }
 
-  /**
-   * Get the world position of the center of mass. Do not modify.
-   */
+  /// Get the world position of the center of mass. Do not modify.
   Vector2 get worldCenter => _sweep.c;
 
-  /**
-   * Get the local position of the center of mass. Do not modify.
-   */
+  /// Get the local position of the center of mass. Do not modify.
   Vector2 getLocalCenter() {
     return _sweep.localCenter;
   }
 
-  /**
-   * Set the linear velocity of the center of mass.
-   *
-   * @param v the new linear velocity of the center of mass.
-   */
+  /// Set the linear velocity of the center of mass.
+  ///
+  /// @param v the new linear velocity of the center of mass.
   void set linearVelocity(Vector2 v) {
     if (_bodyType == BodyType.STATIC) {
       return;
@@ -368,19 +341,15 @@ class Body {
     _linearVelocity.setFrom(v);
   }
 
-  /**
-   * Get the linear velocity of the center of mass. Do not modify, instead use
-   * {@link #setLinearVelocity(Vec2)}.
-   *
-   * @return the linear velocity of the center of mass.
-   */
+  /// Get the linear velocity of the center of mass. Do not modify, instead use
+  /// {@link #setLinearVelocity(Vec2)}.
+  ///
+  /// @return the linear velocity of the center of mass.
   Vector2 get linearVelocity => _linearVelocity;
 
-  /**
-   * Set the angular velocity.
-   *
-   * @param omega the new angular velocity in radians/second.
-   */
+  /// Set the angular velocity.
+  ///
+  /// @param omega the new angular velocity in radians/second.
   void set angularVelocity(double w) {
     if (_bodyType == BodyType.STATIC) {
       return;
@@ -393,22 +362,18 @@ class Body {
     _angularVelocity = w;
   }
 
-  /**
-   * Get the angular velocity.
-   *
-   * @return the angular velocity in radians/second.
-   */
+  /// Get the angular velocity.
+  ///
+  /// @return the angular velocity in radians/second.
   double get angularVelocity {
     return _angularVelocity;
   }
 
-  /**
-   * Apply a force at a world point. If the force is not applied at the center of mass, it will
-   * generate a torque and affect the angular velocity. This wakes up the body.
-   *
-   * @param force the world force vector, usually in Newtons (N).
-   * @param point the world position of the point of application.
-   */
+  /// Apply a force at a world point. If the force is not applied at the center of mass, it will
+  /// generate a torque and affect the angular velocity. This wakes up the body.
+  ///
+  /// @param force the world force vector, usually in Newtons (N).
+  /// @param point the world position of the point of application.
   void applyForce(Vector2 force, Vector2 point) {
     if (_bodyType != BodyType.DYNAMIC) {
       return;
@@ -418,11 +383,6 @@ class Body {
       setAwake(true);
     }
 
-    // _force.addLocal(force);
-    // Vec2 temp = tltemp.get();
-    // temp.set(point).subLocal(_sweep.c);
-    // _torque += Vec2.cross(temp, force);
-
     _force.x += force.x;
     _force.y += force.y;
 
@@ -430,11 +390,9 @@ class Body {
         (point.x - _sweep.c.x) * force.y - (point.y - _sweep.c.y) * force.x;
   }
 
-  /**
-   * Apply a force to the center of mass. This wakes up the body.
-   *
-   * @param force the world force vector, usually in Newtons (N).
-   */
+  /// Apply a force to the center of mass. This wakes up the body.
+  ///
+  /// @param force the world force vector, usually in Newtons (N).
   void applyForceToCenter(Vector2 force) {
     if (_bodyType != BodyType.DYNAMIC) {
       return;
@@ -448,12 +406,10 @@ class Body {
     _force.y += force.y;
   }
 
-  /**
-   * Apply a torque. This affects the angular velocity without affecting the linear velocity of the
-   * center of mass. This wakes up the body.
-   *
-   * @param torque about the z-axis (out of the screen), usually in N-m.
-   */
+  /// Apply a torque. This affects the angular velocity without affecting the linear velocity of the
+  /// center of mass. This wakes up the body.
+  ///
+  /// @param torque about the z-axis (out of the screen), usually in N-m.
   void applyTorque(double torque) {
     if (_bodyType != BodyType.DYNAMIC) {
       return;
@@ -466,16 +422,14 @@ class Body {
     torque += torque;
   }
 
-  /**
-   * Apply an impulse at a point. This immediately modifies the velocity. It also modifies the
-   * angular velocity if the point of application is not at the center of mass. This wakes up the
-   * body if 'wake' is set to true. If the body is sleeping and 'wake' is false, then there is no
-   * effect.
-   *
-   * @param impulse the world impulse vector, usually in N-seconds or kg-m/s.
-   * @param point the world position of the point of application.
-   * @param wake also wake up the body
-   */
+  /// Apply an impulse at a point. This immediately modifies the velocity. It also modifies the
+  /// angular velocity if the point of application is not at the center of mass. This wakes up the
+  /// body if 'wake' is set to true. If the body is sleeping and 'wake' is false, then there is no
+  /// effect.
+  ///
+  /// @param impulse the world impulse vector, usually in N-seconds or kg-m/s.
+  /// @param point the world position of the point of application.
+  /// @param wake also wake up the body
   void applyLinearImpulse(Vector2 impulse, Vector2 point, bool wake) {
     if (_bodyType != BodyType.DYNAMIC) {
       return;
@@ -497,11 +451,9 @@ class Body {
             (point.y - _sweep.c.y) * impulse.x);
   }
 
-  /**
-   * Apply an angular impulse.
-   *
-   * @param impulse the angular impulse in units of kg*m*m/s
-   */
+  /// Apply an angular impulse.
+  ///
+  /// @param impulse the angular impulse in units of kg*m*m/s
   void applyAngularImpulse(double impulse) {
     if (_bodyType != BodyType.DYNAMIC) {
       return;
@@ -513,18 +465,14 @@ class Body {
     _angularVelocity += _invI * impulse;
   }
 
-  /**
-   * Get the total mass of the body.
-   *
-   * @return the mass, usually in kilograms (kg).
-   */
+  /// Get the total mass of the body.
+  ///
+  /// @return the mass, usually in kilograms (kg).
   double get mass => _mass;
 
-  /**
-   * Get the central rotational inertia of the body.
-   *
-   * @return the rotational inertia, usually in kg-m^2.
-   */
+  /// Get the central rotational inertia of the body.
+  ///
+  /// @return the rotational inertia, usually in kg-m^2.
   double getInertia() {
     return _I +
         _mass *
@@ -532,11 +480,9 @@ class Body {
                 _sweep.localCenter.y * _sweep.localCenter.y);
   }
 
-  /**
-   * Get the mass data of the body. The rotational inertia is relative to the center of mass.
-   *
-   * @return a struct containing the mass, inertia and center of the body.
-   */
+  /// Get the mass data of the body. The rotational inertia is relative to the center of mass.
+  ///
+  /// @return a struct containing the mass, inertia and center of the body.
   void getMassData(MassData data) {
     // data.mass = _mass;
     // data.I = _I + _mass * Vec2.dot(_sweep.localCenter, _sweep.localCenter);
@@ -551,13 +497,11 @@ class Body {
     data.center.y = _sweep.localCenter.y;
   }
 
-  /**
-   * Set the mass properties to override the mass properties of the fixtures. Note that this changes
-   * the center of mass position. Note that creating or destroying fixtures can also alter the mass.
-   * This function has no effect if the body isn't dynamic.
-   *
-   * @param massData the mass properties.
-   */
+  /// Set the mass properties to override the mass properties of the fixtures. Note that this changes
+  /// the center of mass position. Note that creating or destroying fixtures can also alter the mass.
+  /// This function has no effect if the body isn't dynamic.
+  ///
+  /// @param massData the mass properties.
   void setMassData(MassData massData) {
     // TODO_ERIN adjust linear velocity and torque to account for movement of center.
     assert(world.isLocked() == false);
@@ -606,11 +550,9 @@ class Body {
 
   final MassData _pmd = MassData();
 
-  /**
-   * This resets the mass properties to the sum of the mass properties of the fixtures. This
-   * normally does not need to be called unless you called setMassData to override the mass and you
-   * later want to reset the mass.
-   */
+  /// This resets the mass properties to the sum of the mass properties of the fixtures. This
+  /// normally does not need to be called unless you called setMassData to override the mass and you
+  /// later want to reset the mass.
   void resetMassData() {
     // Compute mass data from shapes. Each shape has its own density.
     _mass = 0.0;
@@ -686,12 +628,10 @@ class Body {
     world.getPool().pushVec2(3);
   }
 
-  /**
-   * Get the world coordinates of a point given the local coordinates.
-   *
-   * @param localPoint a point on the body measured relative the the body's origin.
-   * @return the same point expressed in world coordinates.
-   */
+  /// Get the world coordinates of a point given the local coordinates.
+  ///
+  /// @param localPoint a point on the body measured relative the the body's origin.
+  /// @return the same point expressed in world coordinates.
   Vector2 getWorldPoint(Vector2 localPoint) {
     Vector2 v = Vector2.zero();
     getWorldPointToOut(localPoint, v);
@@ -702,12 +642,10 @@ class Body {
     Transform.mulToOutVec2(_transform, localPoint, out);
   }
 
-  /**
-   * Get the world coordinates of a vector given the local coordinates.
-   *
-   * @param localVector a vector fixed in the body.
-   * @return the same vector expressed in world coordinates.
-   */
+  /// Get the world coordinates of a vector given the local coordinates.
+  ///
+  /// @param localVector a vector fixed in the body.
+  /// @return the same vector expressed in world coordinates.
   Vector2 getWorldVector(Vector2 localVector) {
     Vector2 out = Vector2.zero();
     getWorldVectorToOut(localVector, out);
@@ -722,12 +660,10 @@ class Body {
     Rot.mulToOutUnsafe(_transform.q, localVector, out);
   }
 
-  /**
-   * Gets a local point relative to the body's origin given a world point.
-   *
-   * @param a point in world coordinates.
-   * @return the corresponding local point relative to the body's origin.
-   */
+  /// Gets a local point relative to the body's origin given a world point.
+  ///
+  /// @param a point in world coordinates.
+  /// @return the corresponding local point relative to the body's origin.
   Vector2 getLocalPoint(Vector2 worldPoint) {
     Vector2 out = Vector2.zero();
     getLocalPointToOut(worldPoint, out);
@@ -738,12 +674,10 @@ class Body {
     Transform.mulTransToOutVec2(_transform, worldPoint, out);
   }
 
-  /**
-   * Gets a local vector given a world vector.
-   *
-   * @param a vector in world coordinates.
-   * @return the corresponding local vector.
-   */
+  /// Gets a local vector given a world vector.
+  ///
+  /// @param a vector in world coordinates.
+  /// @return the corresponding local vector.
   Vector2 getLocalVector(Vector2 worldVector) {
     Vector2 out = Vector2.zero();
     getLocalVectorToOut(worldVector, out);
@@ -758,12 +692,10 @@ class Body {
     Rot.mulTransUnsafeVec2(_transform.q, worldVector, out);
   }
 
-  /**
-   * Get the world linear velocity of a world point attached to this body.
-   *
-   * @param a point in world coordinates.
-   * @return the world velocity of a point.
-   */
+  /// Get the world linear velocity of a world point attached to this body.
+  ///
+  /// @param a point in world coordinates.
+  /// @return the world velocity of a point.
   Vector2 getLinearVelocityFromWorldPoint(Vector2 worldPoint) {
     Vector2 out = Vector2.zero();
     getLinearVelocityFromWorldPointToOut(worldPoint, out);
@@ -777,12 +709,10 @@ class Body {
     out.y = _angularVelocity * tempX + _linearVelocity.y;
   }
 
-  /**
-   * Get the world velocity of a local point.
-   *
-   * @param a point in local coordinates.
-   * @return the world velocity of a point.
-   */
+  /// Get the world velocity of a local point.
+  ///
+  /// @param a point in local coordinates.
+  /// @return the world velocity of a point.
   Vector2 getLinearVelocityFromLocalPoint(Vector2 localPoint) {
     Vector2 out = Vector2.zero();
     getLinearVelocityFromLocalPointToOut(localPoint, out);
@@ -798,11 +728,9 @@ class Body {
     return _bodyType;
   }
 
-  /**
-   * Set the type of this body. This may alter the mass and velocity.
-   *
-   * @param type
-   */
+  /// Set the type of this body. This may alter the mass and velocity.
+  ///
+  /// @param type
   void setType(BodyType type) {
     assert(world.isLocked() == false);
     if (world.isLocked() == true) {
@@ -849,12 +777,12 @@ class Body {
     }
   }
 
-  /** Is this body treated like a bullet for continuous collision detection? */
+  /// Is this body treated like a bullet for continuous collision detection?
   bool isBullet() {
     return (_flags & BULLET_FLAG) == BULLET_FLAG;
   }
 
-  /** Should this body be treated like a bullet for continuous collision detection? */
+  /// Should this body be treated like a bullet for continuous collision detection?
   void setBullet(bool flag) {
     if (flag) {
       _flags |= BULLET_FLAG;
@@ -863,11 +791,9 @@ class Body {
     }
   }
 
-  /**
-   * You can disable sleeping on this body. If you disable sleeping, the body will be woken.
-   *
-   * @param flag
-   */
+  /// You can disable sleeping on this body. If you disable sleeping, the body will be woken.
+  ///
+  /// @param flag
   void setSleepingAllowed(bool flag) {
     if (flag) {
       _flags |= AUTO_SLEEP_FLAG;
@@ -877,21 +803,17 @@ class Body {
     }
   }
 
-  /**
-   * Is this body allowed to sleep
-   *
-   * @return
-   */
+  /// Is this body allowed to sleep
+  ///
+  /// @return
   bool isSleepingAllowed() {
     return (_flags & AUTO_SLEEP_FLAG) == AUTO_SLEEP_FLAG;
   }
 
-  /**
-   * Set the sleep state of the body. A sleeping body has very low CPU cost.
-   *
-   * @param flag set to true to put body to sleep, false to wake it.
-   * @param flag
-   */
+  /// Set the sleep state of the body. A sleeping body has very low CPU cost.
+  ///
+  /// @param flag set to true to put body to sleep, false to wake it.
+  /// @param flag
   void setAwake(bool flag) {
     if (flag) {
       if ((_flags & AWAKE_FLAG) == 0) {
@@ -908,27 +830,21 @@ class Body {
     }
   }
 
-  /**
-   * Get the sleeping state of this body.
-   *
-   * @return true if the body is awake.
-   */
+  /// Get the sleeping state of this body.
+  ///
+  /// @return true if the body is awake.
   bool isAwake() {
     return (_flags & AWAKE_FLAG) == AWAKE_FLAG;
   }
 
-  /**
-   * Set the active state of the body. An inactive body is not simulated and cannot be collided with
-   * or woken up. If you pass a flag of true, all fixtures will be added to the broad-phase. If you
-   * pass a flag of false, all fixtures will be removed from the broad-phase and all contacts will
-   * be destroyed. Fixtures and joints are otherwise unaffected. You may continue to create/destroy
-   * fixtures and joints on inactive bodies. Fixtures on an inactive body are implicitly inactive
-   * and will not participate in collisions, ray-casts, or queries. Joints connected to an inactive
-   * body are implicitly inactive. An inactive body is still owned by a World object and remains in
-   * the body list.
-   *
-   * @param flag
-   */
+  /// Set the active state of the body. An inactive body is not simulated and cannot be collided with
+  /// or woken up. If you pass a flag of true, all fixtures will be added to the broad-phase. If you
+  /// pass a flag of false, all fixtures will be removed from the broad-phase and all contacts will
+  /// be destroyed. Fixtures and joints are otherwise unaffected. You may continue to create/destroy
+  /// fixtures and joints on inactive bodies. Fixtures on an inactive body are implicitly inactive
+  /// and will not participate in collisions, ray-casts, or queries. Joints connected to an inactive
+  /// body are implicitly inactive. An inactive body is still owned by a World object and remains in
+  /// the body list.
   void setActive(bool flag) {
     assert(world.isLocked() == false);
 
@@ -966,20 +882,16 @@ class Body {
     }
   }
 
-  /**
-   * Get the active state of the body.
-   *
-   * @return
-   */
+  /// Get the active state of the body.
+  ///
+  /// @return
   bool isActive() {
     return (_flags & ACTIVE_FLAG) == ACTIVE_FLAG;
   }
 
-  /**
-   * Set this body to have fixed rotation. This causes the mass to be reset.
-   *
-   * @param flag
-   */
+  /// Set this body to have fixed rotation. This causes the mass to be reset.
+  ///
+  /// @param flag
   void setFixedRotation(bool flag) {
     if (flag) {
       _flags |= FIXED_ROTATION_FLAG;
@@ -990,36 +902,32 @@ class Body {
     resetMassData();
   }
 
-  /**
-   * Does this body have fixed rotation?
-   *
-   * @return
-   */
+  /// Does this body have fixed rotation?
+  ///
+  /// @return
   bool isFixedRotation() {
     return (_flags & FIXED_ROTATION_FLAG) == FIXED_ROTATION_FLAG;
   }
 
-  /** Get the list of all fixtures attached to this body. */
+  /// Get the list of all fixtures attached to this body.
   Fixture getFixtureList() {
     return _fixtureList;
   }
 
-  /** Get the list of all joints attached to this body. */
+  /// Get the list of all joints attached to this body.
   JointEdge getJointList() {
     return _jointList;
   }
 
-  /**
-   * Get the list of all contacts attached to this body.
-   *
-   * @warning this list changes during the time step and you may miss some collisions if you don't
-   *          use ContactListener.
-   */
+  /// Get the list of all contacts attached to this body.
+  ///
+  /// @warning this list changes during the time step and you may miss some collisions if you don't
+  /// use ContactListener.
   ContactEdge getContactList() {
     return _contactList;
   }
 
-  /** Get the next body in the world's body list. */
+  /// Get the next body in the world's body list.
   Body getNext() {
     return _next;
   }
@@ -1065,13 +973,11 @@ class Body {
     _transform.p.y = _sweep.c.y - q.s * v.x - q.c * v.y;
   }
 
-  /**
-   * This is used to prevent connected bodies from colliding. It may lie, depending on the
-   * collideConnected flag.
-   *
-   * @param other
-   * @return
-   */
+  /// This is used to prevent connected bodies from colliding. It may lie, depending on the
+  /// collideConnected flag.
+  ///
+  /// @param other
+  /// @return
   bool shouldCollide(Body other) {
     // At least one body should be dynamic.
     if (_bodyType != BodyType.DYNAMIC && other._bodyType != BodyType.DYNAMIC) {

--- a/lib/src/dynamics/body_def.dart
+++ b/lib/src/dynamics/body_def.dart
@@ -24,307 +24,220 @@
 
 part of box2d;
 
-/**
- * A body definition holds all the data needed to construct a rigid body. You can safely re-use body
- * definitions. Shapes are added to a body after construction.
-
- */
+/// A body definition holds all the data needed to construct a rigid body. You can safely re-use body
+/// definitions. Shapes are added to a body after construction.
 class BodyDef {
-  /**
-   * The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
-   * mass is set to one.
-   */
+  /// The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
+  /// mass is set to one.
   BodyType type = BodyType.STATIC;
 
-  /**
-   * Use this to store application specific body data.
-   */
+  /// Use this to store application specific body data.
   Object userData;
 
-  /**
-   * The world position of the body. Avoid creating bodies at the origin since this can lead to many
-   * overlapping shapes.
-   */
+  /// The world position of the body. Avoid creating bodies at the origin since this can lead to many
+  /// overlapping shapes.
   Vector2 position = new Vector2.zero();
 
-  /**
-   * The world angle of the body in radians.
-   */
+  /// The world angle of the body in radians.
   double angle = 0.0;
 
-  /**
-   * The linear velocity of the body in world co-ordinates.
-   */
+  /// The linear velocity of the body in world co-ordinates.
   Vector2 linearVelocity = new Vector2.zero();
 
-  /**
-   * The angular velocity of the body.
-   */
+  /// The angular velocity of the body.
   double angularVelocity = 0.0;
 
-  /**
-   * Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
-   * 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-   * large.
-   */
+  /// Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
+  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
+  /// large.
   double linearDamping = 0.0;
 
-  /**
-   * Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
-   * 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-   * large.
-   */
+  /// Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
+  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
+  /// large.
   double angularDamping = 0.0;
 
-  /**
-   * Set this flag to false if this body should never fall asleep. Note that this increases CPU
-   * usage.
-   */
+  /// Set this flag to false if this body should never fall asleep. Note that this increases CPU
+  /// usage.
   bool allowSleep = true;
 
-  /**
-   * Is this body initially sleeping?
-   */
+  /// Is this body initially sleeping?
   bool awake = true;
 
-  /**
-   * Should this body be prevented from rotating? Useful for characters.
-   */
+  /// Should this body be prevented from rotating? Useful for characters.
   bool fixedRotation = false;
 
-  /**
-   * Is this a fast moving body that should be prevented from tunneling through other moving bodies?
-   * Note that all bodies are prevented from tunneling through kinematic and static bodies. This
-   * setting is only considered on dynamic bodies.
-   * 
-   * @warning You should use this flag sparingly since it increases processing time.
-   */
+  /// Is this a fast moving body that should be prevented from tunneling through other moving bodies?
+  /// Note that all bodies are prevented from tunneling through kinematic and static bodies. This
+  /// setting is only considered on dynamic bodies.
+  ///
+  /// @warning You should use this flag sparingly since it increases processing time.
   bool bullet = false;
 
-  /**
-   * Does this body start out active?
-   */
+  /// Does this body start out active?
   bool active = true;
 
-  /**
-   * Experimental: scales the inertia tensor.
-   */
+  /// Experimental: scales the inertia tensor.
   double gravityScale = 1.0;
 
-  /**
-   * The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
-   * mass is set to one.
-   */
+  /// The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
+  /// mass is set to one.
   BodyType getType() {
     return type;
   }
 
-  /**
-   * The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
-   * mass is set to one.
-   */
+  /// The body type: static, kinematic, or dynamic. Note: if a dynamic body would have zero mass, the
+  /// mass is set to one.
   void setType(BodyType type) {
     this.type = type;
   }
 
-  /**
-   * Use this to store application specific body data.
-   */
+  /// Use this to store application specific body data.
   Object getUserData() {
     return userData;
   }
 
-  /**
-   * Use this to store application specific body data.
-   */
+  /// Use this to store application specific body data.
   void setUserData(Object userData) {
     this.userData = userData;
   }
 
-  /**
-   * The world position of the body. Avoid creating bodies at the origin since this can lead to many
-   * overlapping shapes.
-   */
+  /// The world position of the body. Avoid creating bodies at the origin since this can lead to many
+  /// overlapping shapes.
   Vector2 getPosition() {
     return position;
   }
 
-  /**
-   * The world position of the body. Avoid creating bodies at the origin since this can lead to many
-   * overlapping shapes.
-   */
+  /// The world position of the body. Avoid creating bodies at the origin since this can lead to many
+  /// overlapping shapes.
   void setPosition(Vector2 position) {
     this.position = position;
   }
 
-  /**
-   * The world angle of the body in radians.
-   */
+  /// The world angle of the body in radians.
   double getAngle() {
     return angle;
   }
 
-  /**
-   * The world angle of the body in radians.
-   */
+  /// The world angle of the body in radians.
   void setAngle(double angle) {
     this.angle = angle;
   }
 
-  /**
-   * The linear velocity of the body in world co-ordinates.
-   */
+  /// The linear velocity of the body in world co-ordinates.
   Vector2 getLinearVelocity() {
     return linearVelocity;
   }
 
-  /**
-   * The linear velocity of the body in world co-ordinates.
-   */
+  /// The linear velocity of the body in world co-ordinates.
   void setLinearVelocity(Vector2 linearVelocity) {
     this.linearVelocity = linearVelocity;
   }
 
-  /**
-   * The angular velocity of the body.
-   */
+  /// The angular velocity of the body.
   double getAngularVelocity() {
     return angularVelocity;
   }
 
-  /**
-   * The angular velocity of the body.
-   */
+  /// The angular velocity of the body.
   void setAngularVelocity(double angularVelocity) {
     this.angularVelocity = angularVelocity;
   }
 
-  /**
-   * Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
-   * 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-   * large.
-   */
+  /// Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
+  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
+  /// large.
   double getLinearDamping() {
     return linearDamping;
   }
 
-  /**
-   * Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
-   * 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-   * large.
-   */
+  /// Linear damping is use to reduce the linear velocity. The damping parameter can be larger than
+  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
+  /// large.
   void setLinearDamping(double linearDamping) {
     this.linearDamping = linearDamping;
   }
 
-  /**
-   * Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
-   * 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-   * large.
-   */
+  /// Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
+  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
+  /// large.
   double getAngularDamping() {
     return angularDamping;
   }
 
-  /**
-   * Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
-   * 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
-   * large.
-   */
+  /// Angular damping is use to reduce the angular velocity. The damping parameter can be larger than
+  /// 1.0f but the damping effect becomes sensitive to the time step when the damping parameter is
+  /// large.
   void setAngularDamping(double angularDamping) {
     this.angularDamping = angularDamping;
   }
 
-  /**
-   * Set this flag to false if this body should never fall asleep. Note that this increases CPU
-   * usage.
-   */
+  /// Set this flag to false if this body should never fall asleep. Note that this increases CPU
+  /// usage.
   bool isAllowSleep() {
     return allowSleep;
   }
 
-  /**
-   * Set this flag to false if this body should never fall asleep. Note that this increases CPU
-   * usage.
-   */
+  /// Set this flag to false if this body should never fall asleep. Note that this increases CPU
+  /// usage.
   void setAllowSleep(bool allowSleep) {
     this.allowSleep = allowSleep;
   }
 
-  /**
-   * Is this body initially sleeping?
-   */
+  /// Is this body initially sleeping?
   bool isAwake() {
     return awake;
   }
 
-  /**
-   * Is this body initially sleeping?
-   */
+  /// Is this body initially sleeping?
   void setAwake(bool awake) {
     this.awake = awake;
   }
 
-  /**
-   * Should this body be prevented from rotating? Useful for characters.
-   */
+  /// Should this body be prevented from rotating? Useful for characters.
   bool isFixedRotation() {
     return fixedRotation;
   }
 
-  /**
-   * Should this body be prevented from rotating? Useful for characters.
-   */
+  /// Should this body be prevented from rotating? Useful for characters.
   void setFixedRotation(bool fixedRotation) {
     this.fixedRotation = fixedRotation;
   }
 
-  /**
-   * Is this a fast moving body that should be prevented from tunneling through other moving bodies?
-   * Note that all bodies are prevented from tunneling through kinematic and static bodies. This
-   * setting is only considered on dynamic bodies.
-   * 
-   * @warning You should use this flag sparingly since it increases processing time.
-   */
+  /// Is this a fast moving body that should be prevented from tunneling through other moving bodies?
+  /// Note that all bodies are prevented from tunneling through kinematic and static bodies. This
+  /// setting is only considered on dynamic bodies.
+  ///
+  /// @warning You should use this flag sparingly since it increases processing time.
   bool isBullet() {
     return bullet;
   }
 
-  /**
-   * Is this a fast moving body that should be prevented from tunneling through other moving bodies?
-   * Note that all bodies are prevented from tunneling through kinematic and static bodies. This
-   * setting is only considered on dynamic bodies.
-   * 
-   * @warning You should use this flag sparingly since it increases processing time.
-   */
+  /// Is this a fast moving body that should be prevented from tunneling through other moving bodies?
+  /// Note that all bodies are prevented from tunneling through kinematic and static bodies. This
+  /// setting is only considered on dynamic bodies.
+  ///
+  /// @warning You should use this flag sparingly since it increases processing time.
   void setBullet(bool bullet) {
     this.bullet = bullet;
   }
 
-  /**
-   * Does this body start out active?
-   */
+  /// Does this body start out active?
   bool isActive() {
     return active;
   }
 
-  /**
-   * Does this body start out active?
-   */
+  /// Does this body start out active?
   void setActive(bool active) {
     this.active = active;
   }
 
-  /**
-   * Experimental: scales the inertia tensor.
-   */
+  /// Experimental: scales the inertia tensor.
   double getGravityScale() {
     return gravityScale;
   }
 
-  /**
-   * Experimental: scales the inertia tensor.
-   */
+  /// Experimental: scales the inertia tensor.
   void setGravityScale(double gravityScale) {
     this.gravityScale = gravityScale;
   }

--- a/lib/src/dynamics/body_type.dart
+++ b/lib/src/dynamics/body_type.dart
@@ -1,10 +1,7 @@
 part of box2d;
 
-/**
- * The body type.
- * static: zero mass, zero velocity, may be manually moved
- * kinematic: zero mass, non-zero velocity set by user, moved by solver
- * dynamic: positive mass, non-zero velocity determined by forces, moved by solver
- * 
- */
+/// The body type.
+/// static: zero mass, zero velocity, may be manually moved
+/// kinematic: zero mass, non-zero velocity set by user, moved by solver
+/// dynamic: positive mass, non-zero velocity determined by forces, moved by solver
 enum BodyType { STATIC, KINEMATIC, DYNAMIC }

--- a/lib/src/dynamics/contact_manager.dart
+++ b/lib/src/dynamics/contact_manager.dart
@@ -1,35 +1,30 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * Delegate of World.
- *
- * @author Daniel Murphy
- */
-
+/// Delegate of World.
 class ContactManager implements PairCallback {
   BroadPhase broadPhase;
   Contact contactList;
@@ -46,12 +41,7 @@ class ContactManager implements PairCallback {
     broadPhase = broadPhase_;
   }
 
-  /**
-   * Broad-phase callback.
-   *
-   * @param proxyUserDataA
-   * @param proxyUserDataB
-   */
+  /// Broad-phase callback.
   void addPair(FixtureProxy proxyUserDataA, FixtureProxy proxyUserDataB) {
     FixtureProxy proxyA = proxyUserDataA;
     FixtureProxy proxyB = proxyUserDataB;
@@ -219,10 +209,8 @@ class ContactManager implements PairCallback {
     --contactCount;
   }
 
-  /**
-   * This is the top level collision call for the time step. Here all the narrow phase collision is
-   * processed for the world contact list.
-   */
+  /// This is the top level collision call for the time step. Here all the narrow phase collision is
+  /// processed for the world contact list.
   void collide() {
     // Update awake contacts.
     Contact c = contactList;

--- a/lib/src/dynamics/contacts/chain_and_circle_contact.dart
+++ b/lib/src/dynamics/contacts/chain_and_circle_contact.dart
@@ -33,7 +33,7 @@ class ChainAndCircleContact extends Contact {
     assert(_fixtureB.getType() == ShapeType.CIRCLE);
   }
 
-  final EdgeShape _edge = new EdgeShape();
+  final EdgeShape _edge = EdgeShape();
 
   void evaluate(Manifold manifold, Transform xfA, Transform xfB) {
     final chain = _fixtureA.getShape() as ChainShape;

--- a/lib/src/dynamics/contacts/chain_and_polygon_contact.dart
+++ b/lib/src/dynamics/contacts/chain_and_polygon_contact.dart
@@ -33,7 +33,7 @@ class ChainAndPolygonContact extends Contact {
     assert(_fixtureB.getType() == ShapeType.POLYGON);
   }
 
-  final EdgeShape _edge = new EdgeShape();
+  final EdgeShape _edge = EdgeShape();
 
   void evaluate(Manifold manifold, Transform xfA, Transform xfB) {
     final chain = _fixtureA.getShape() as ChainShape;

--- a/lib/src/dynamics/contacts/contact.dart
+++ b/lib/src/dynamics/contacts/contact.dart
@@ -51,8 +51,8 @@ abstract class Contact {
   Contact _next;
 
   // Nodes for connecting bodies.
-  ContactEdge _nodeA = new ContactEdge();
-  ContactEdge _nodeB = new ContactEdge();
+  ContactEdge _nodeA = ContactEdge();
+  ContactEdge _nodeB = ContactEdge();
 
   Fixture _fixtureA;
   Fixture _fixtureB;
@@ -60,7 +60,7 @@ abstract class Contact {
   int _indexA = 0;
   int _indexB = 0;
 
-  final Manifold _manifold = new Manifold();
+  final Manifold _manifold = Manifold();
 
   int _toiCount = 0;
   double _toi = 0.0;
@@ -201,7 +201,7 @@ abstract class Contact {
   }
 
   // djm pooling
-  final Manifold _oldManifold = new Manifold();
+  final Manifold _oldManifold = Manifold();
 
   void update(ContactListener listener) {
     _oldManifold.set(_manifold);

--- a/lib/src/dynamics/contacts/contact.dart
+++ b/lib/src/dynamics/contacts/contact.dart
@@ -1,34 +1,31 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 part of box2d;
 
-/**
- * The class manages contact between two shapes. A contact exists for each overlapping AABB in the
- * broad-phase (except if filtered). Therefore a contact object may exist that has no contact
- * points.
- *
- */
+/// The class manages contact between two shapes. A contact exists for each overlapping AABB in the
+/// broad-phase (except if filtered). Therefore a contact object may exist that has no contact
+/// points.
 abstract class Contact {
   // Flags stored in _flags
   // Used when crawling contact graph when forming islands.
@@ -74,7 +71,7 @@ abstract class Contact {
 
   Contact(this._pool);
 
-  /** initialization for pooling */
+  /// initialization for pooling
   void init(Fixture fA, int indexA, Fixture fB, int indexB) {
     _flags = ENABLED_FLAG;
 
@@ -106,9 +103,7 @@ abstract class Contact {
     _tangentSpeed = 0.0;
   }
 
-  /**
-   * Get the world manifold.
-   */
+  /// Get the world manifold.
   void getWorldManifold(WorldManifold worldManifold) {
     final Body bodyA = _fixtureA.getBody();
     final Body bodyB = _fixtureB.getBody();
@@ -119,21 +114,13 @@ abstract class Contact {
         bodyB._transform, shapeB.radius);
   }
 
-  /**
-   * Is this contact touching
-   *
-   * @return
-   */
+  /// Is this contact touching
   bool isTouching() {
     return (_flags & TOUCHING_FLAG) == TOUCHING_FLAG;
   }
 
-  /**
-   * Enable/disable this contact. This can be used inside the pre-solve contact listener. The
-   * contact is only disabled for the current time step (or sub-step in continuous collisions).
-   *
-   * @param flag
-   */
+  /// Enable/disable this contact. This can be used inside the pre-solve contact listener. The
+  /// contact is only disabled for the current time step (or sub-step in continuous collisions).
   void setEnabled(bool flag) {
     if (flag) {
       _flags |= ENABLED_FLAG;
@@ -142,40 +129,24 @@ abstract class Contact {
     }
   }
 
-  /**
-   * Has this contact been disabled?
-   *
-   * @return
-   */
+  /// Has this contact been disabled?
   bool isEnabled() {
     return (_flags & ENABLED_FLAG) == ENABLED_FLAG;
   }
 
-  /**
-   * Get the next contact in the world's contact list.
-   *
-   * @return
-   */
+  /// Get the next contact in the world's contact list.
   Contact getNext() {
     return _next;
   }
 
-  /**
-   * Get the first fixture in this contact.
-   *
-   * @return
-   */
+  /// Get the first fixture in this contact.
   Fixture get fixtureA => _fixtureA;
 
   int getChildIndexA() {
     return _indexA;
   }
 
-  /**
-   * Get the second fixture in this contact.
-   *
-   * @return
-   */
+  /// Get the second fixture in this contact.
   Fixture get fixtureB => _fixtureB;
 
   int getChildIndexB() {
@@ -193,9 +164,7 @@ abstract class Contact {
 
   void evaluate(Manifold manifold, Transform xfA, Transform xfB);
 
-  /**
-   * Flag this contact for filtering. Filtering will occur the next time step.
-   */
+  /// Flag this contact for filtering. Filtering will occur the next time step.
   void flagForFiltering() {
     _flags |= FILTER_FLAG;
   }
@@ -284,26 +253,14 @@ abstract class Contact {
     }
   }
 
-  /**
-   * Friction mixing law. The idea is to allow either fixture to drive the restitution to zero. For
-   * example, anything slides on ice.
-   *
-   * @param friction1
-   * @param friction2
-   * @return
-   */
+  /// Friction mixing law. The idea is to allow either fixture to drive the restitution to zero. For
+  /// example, anything slides on ice.
   static double mixFriction(double friction1, double friction2) {
     return Math.sqrt(friction1 * friction2);
   }
 
-  /**
-   * Restitution mixing law. The idea is allow for anything to bounce off an inelastic surface. For
-   * example, a superball bounces on anything.
-   *
-   * @param restitution1
-   * @param restitution2
-   * @return
-   */
+  /// Restitution mixing law. The idea is allow for anything to bounce off an inelastic surface. For
+  /// example, a superball bounces on anything.
   static double mixRestitution(double restitution1, double restitution2) {
     return restitution1 > restitution2 ? restitution1 : restitution2;
   }

--- a/lib/src/dynamics/contacts/contact_edge.dart
+++ b/lib/src/dynamics/contacts/contact_edge.dart
@@ -24,30 +24,20 @@
 
 part of box2d;
 
-/**
- * A contact edge is used to connect bodies and contacts together in a contact graph where each body
- * is a node and each contact is an edge. A contact edge belongs to a doubly linked list maintained
- * in each attached body. Each contact has two contact nodes, one for each attached body.
- * 
- */
+/// A contact edge is used to connect bodies and contacts together in a contact graph where each body
+/// is a node and each contact is an edge. A contact edge belongs to a doubly linked list maintained
+/// in each attached body. Each contact has two contact nodes, one for each attached body.
+///
 class ContactEdge {
-  /**
-   * provides quick access to the other body attached.
-   */
+  /// provides quick access to the other body attached.
   Body other;
 
-  /**
-   * the contact
-   */
+  /// the contact
   Contact contact;
 
-  /**
-   * the previous contact edge in the body's contact list
-   */
+  /// the previous contact edge in the body's contact list
   ContactEdge prev;
 
-  /**
-   * the next contact edge in the body's contact list
-   */
+  /// the next contact edge in the body's contact list
   ContactEdge next;
 }

--- a/lib/src/dynamics/contacts/contact_position_and_constraint.dart
+++ b/lib/src/dynamics/contacts/contact_position_and_constraint.dart
@@ -25,14 +25,14 @@
 part of box2d;
 
 class ContactPositionConstraint {
-  List<Vector2> localPoints = new List<Vector2>(Settings.maxManifoldPoints);
-  final Vector2 localNormal = new Vector2.zero();
-  final Vector2 localPoint = new Vector2.zero();
+  List<Vector2> localPoints = List<Vector2>(Settings.maxManifoldPoints);
+  final Vector2 localNormal = Vector2.zero();
+  final Vector2 localPoint = Vector2.zero();
   int indexA = 0;
   int indexB = 0;
   double invMassA = 0.0, invMassB = 0.0;
-  final Vector2 localCenterA = new Vector2.zero();
-  final Vector2 localCenterB = new Vector2.zero();
+  final Vector2 localCenterA = Vector2.zero();
+  final Vector2 localCenterB = Vector2.zero();
   double invIA = 0.0, invIB = 0.0;
   ManifoldType type;
   double radiusA = 0.0, radiusB = 0.0;
@@ -40,7 +40,7 @@ class ContactPositionConstraint {
 
   ContactPositionConstraint() {
     for (int i = 0; i < localPoints.length; i++) {
-      localPoints[i] = new Vector2.zero();
+      localPoints[i] = Vector2.zero();
     }
   }
 }

--- a/lib/src/dynamics/contacts/contact_solver.dart
+++ b/lib/src/dynamics/contacts/contact_solver.dart
@@ -56,12 +56,12 @@ class ContactSolver {
 
   ContactSolver() {
     _positionConstraints =
-        new List<ContactPositionConstraint>(INITIAL_NUM_CONSTRAINTS);
+        List<ContactPositionConstraint>(INITIAL_NUM_CONSTRAINTS);
     _velocityConstraints =
-        new List<ContactVelocityConstraint>(INITIAL_NUM_CONSTRAINTS);
+        List<ContactVelocityConstraint>(INITIAL_NUM_CONSTRAINTS);
     for (int i = 0; i < INITIAL_NUM_CONSTRAINTS; i++) {
-      _positionConstraints[i] = new ContactPositionConstraint();
-      _velocityConstraints[i] = new ContactVelocityConstraint();
+      _positionConstraints[i] = ContactPositionConstraint();
+      _velocityConstraints[i] = ContactVelocityConstraint();
     }
   }
 
@@ -73,20 +73,20 @@ class ContactSolver {
     if (_positionConstraints.length < _count) {
       List<ContactPositionConstraint> old = _positionConstraints;
       _positionConstraints =
-          new List<ContactPositionConstraint>(Math.max(old.length * 2, _count));
+          List<ContactPositionConstraint>(Math.max(old.length * 2, _count));
       BufferUtils.arraycopy(old, 0, _positionConstraints, 0, old.length);
       for (int i = old.length; i < _positionConstraints.length; i++) {
-        _positionConstraints[i] = new ContactPositionConstraint();
+        _positionConstraints[i] = ContactPositionConstraint();
       }
     }
 
     if (_velocityConstraints.length < _count) {
       List<ContactVelocityConstraint> old = _velocityConstraints;
       _velocityConstraints =
-          new List<ContactVelocityConstraint>(Math.max(old.length * 2, _count));
+          List<ContactVelocityConstraint>(Math.max(old.length * 2, _count));
       BufferUtils.arraycopy(old, 0, _velocityConstraints, 0, old.length);
       for (int i = old.length; i < _velocityConstraints.length; i++) {
-        _velocityConstraints[i] = new ContactVelocityConstraint();
+        _velocityConstraints[i] = ContactVelocityConstraint();
       }
     }
 
@@ -211,9 +211,9 @@ class ContactSolver {
 
   // djm pooling, and from above
   // TODO(srdjan): make them private.
-  final Transform xfA = new Transform.zero();
-  final Transform xfB = new Transform.zero();
-  final WorldManifold worldManifold = new WorldManifold();
+  final Transform xfA = Transform.zero();
+  final Transform xfB = Transform.zero();
+  final WorldManifold worldManifold = WorldManifold();
 
   void initializeVelocityConstraints() {
     // Warm start.
@@ -827,7 +827,7 @@ class ContactSolver {
    * -_linearSlop. return minSeparation >= -1.5f * _linearSlop; }
    */
 
-  final PositionSolverManifold _psolver = new PositionSolverManifold();
+  final PositionSolverManifold _psolver = PositionSolverManifold();
 
   /**
    * Sequential solver.
@@ -1024,8 +1024,8 @@ class ContactSolver {
 }
 
 class PositionSolverManifold {
-  final Vector2 normal = new Vector2.zero();
-  final Vector2 point = new Vector2.zero();
+  final Vector2 normal = Vector2.zero();
+  final Vector2 point = Vector2.zero();
   double separation = 0.0;
 
   void initialize(

--- a/lib/src/dynamics/contacts/contact_solver.dart
+++ b/lib/src/dynamics/contacts/contact_solver.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -35,15 +35,12 @@ class ContactSolverDef {
 class ContactSolver {
   static const bool DEBUG_SOLVER = false;
   static const double k_errorTol = 1e-3;
-  /**
-   * For each solver, this is the initial number of constraints in the array, which expands as
-   * needed.
-   */
+
+  /// For each solver, this is the initial number of constraints in the array, which expands as
+  /// needed.
   static const int INITIAL_NUM_CONSTRAINTS = 256;
 
-  /**
-   * Ensure a reasonable condition number. for the block solver
-   */
+  /// Ensure a reasonable condition number. for the block solver
   static final double k_maxConditionNumber = 100.0;
 
   TimeStep _step;
@@ -829,9 +826,7 @@ class ContactSolver {
 
   final PositionSolverManifold _psolver = PositionSolverManifold();
 
-  /**
-   * Sequential solver.
-   */
+  /// Sequential solver.
   bool solvePositionConstraints() {
     double minSeparation = 0.0;
 

--- a/lib/src/dynamics/contacts/contact_velocity_constraint.dart
+++ b/lib/src/dynamics/contacts/contact_velocity_constraint.dart
@@ -25,8 +25,8 @@
 part of box2d;
 
 class VelocityConstraintPoint {
-  final Vector2 rA = new Vector2.zero();
-  final Vector2 rB = new Vector2.zero();
+  final Vector2 rA = Vector2.zero();
+  final Vector2 rB = Vector2.zero();
   double normalImpulse = 0.0;
   double tangentImpulse = 0.0;
   double normalMass = 0.0;
@@ -36,10 +36,10 @@ class VelocityConstraintPoint {
 
 class ContactVelocityConstraint {
   List<VelocityConstraintPoint> points =
-      new List<VelocityConstraintPoint>(Settings.maxManifoldPoints);
-  final Vector2 normal = new Vector2.zero();
-  final Matrix2 normalMass = new Matrix2.zero();
-  final Matrix2 K = new Matrix2.zero();
+      List<VelocityConstraintPoint>(Settings.maxManifoldPoints);
+  final Vector2 normal = Vector2.zero();
+  final Matrix2 normalMass = Matrix2.zero();
+  final Matrix2 K = Matrix2.zero();
   int indexA = 0;
   int indexB = 0;
   double invMassA = 0.0, invMassB = 0.0;
@@ -52,7 +52,7 @@ class ContactVelocityConstraint {
 
   ContactVelocityConstraint() {
     for (int i = 0; i < points.length; i++) {
-      points[i] = new VelocityConstraintPoint();
+      points[i] = VelocityConstraintPoint();
     }
   }
 }

--- a/lib/src/dynamics/contacts/position.dart
+++ b/lib/src/dynamics/contacts/position.dart
@@ -25,6 +25,6 @@
 part of box2d;
 
 class Position {
-  final Vector2 c = new Vector2.zero();
+  final Vector2 c = Vector2.zero();
   double a = 0.0;
 }

--- a/lib/src/dynamics/contacts/velocity.dart
+++ b/lib/src/dynamics/contacts/velocity.dart
@@ -25,6 +25,6 @@
 part of box2d;
 
 class Velocity {
-  final Vector2 v = new Vector2.zero();
+  final Vector2 v = Vector2.zero();
   double w = 0.0;
 }

--- a/lib/src/dynamics/filter.dart
+++ b/lib/src/dynamics/filter.dart
@@ -24,26 +24,18 @@
 
 part of box2d;
 
-/**
- * This holds contact filtering data.
- */
+/// This holds contact filtering data.
 class Filter {
-  /**
-   * The collision category bits. Normally you would just set one bit.
-   */
+  /// The collision category bits. Normally you would just set one bit.
   int categoryBits = 0x0001;
 
-  /**
-   * The collision mask bits. This states the categories that this
-   * shape would accept for collision.
-   */
+  /// The collision mask bits. This states the categories that this
+  /// shape would accept for collision.
   int maskBits = 0xFFFF;
 
-  /**
-   * Collision groups allow a certain group of objects to never collide (negative)
-   * or always collide (positive). Zero means no collision group. Non-zero group
-   * filtering always wins against the mask bits.
-   */
+  /// Collision groups allow a certain group of objects to never collide (negative)
+  /// or always collide (positive). Zero means no collision group. Non-zero group
+  /// filtering always wins against the mask bits.
   int groupIndex = 0;
 
   void set(Filter argOther) {

--- a/lib/src/dynamics/fixture.dart
+++ b/lib/src/dynamics/fixture.dart
@@ -1,38 +1,34 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A fixture is used to attach a shape to a body for collision detection. A fixture inherits its
- * transform from its parent. Fixtures hold additional non-geometric data such as friction,
- * collision filters, etc. Fixtures are created via Body::CreateFixture.
- *
- * @warning you cannot reuse fixtures.
- *
- * @author daniel
- */
+/// A fixture is used to attach a shape to a body for collision detection. A fixture inherits its
+/// transform from its parent. Fixtures hold additional non-geometric data such as friction,
+/// collision filters, etc. Fixtures are created via Body::CreateFixture.
+///
+/// @warning you cannot reuse fixtures.
 class Fixture {
   double _density = 0.0;
 
@@ -51,43 +47,33 @@ class Fixture {
 
   bool _isSensor = false;
 
-  /**
-   * Use this to store your application specific data.
-   */
+  /// Use this to store your application specific data.
   Object userData;
 
-  /**
-   * Get the type of the child shape. You can use this to down cast to the concrete shape.
-   *
-   * @return the shape type.
-   */
+  /// Get the type of the child shape. You can use this to down cast to the concrete shape.
+  ///
+  /// @return the shape type.
   ShapeType getType() => _shape.shapeType;
 
-  /**
-   * Get the child shape. You can modify the child shape, however you should not change the number
-   * of vertices because this will crash some collision caching mechanisms.
-   *
-   * @return
-   */
+  /// Get the child shape. You can modify the child shape, however you should not change the number
+  /// of vertices because this will crash some collision caching mechanisms.
+  ///
+  /// @return
   Shape getShape() {
     return _shape;
   }
 
-  /**
-   * Is this fixture a sensor (non-solid)?
-   *
-   * @return the true if the shape is a sensor.
-   * @return
-   */
+  /// Is this fixture a sensor (non-solid)?
+  ///
+  /// @return the true if the shape is a sensor.
+  /// @return
   bool isSensor() {
     return _isSensor;
   }
 
-  /**
-   * Set if this fixture is a sensor.
-   *
-   * @param sensor
-   */
+  /// Set if this fixture is a sensor.
+  ///
+  /// @param sensor
   void setSensor(bool sensor) {
     if (sensor != _isSensor) {
       _body.setAwake(true);
@@ -95,32 +81,26 @@ class Fixture {
     }
   }
 
-  /**
-   * Set the contact filtering data. This is an expensive operation and should not be called
-   * frequently. This will not update contacts until the next time step when either parent body is
-   * awake. This automatically calls refilter.
-   *
-   * @param filter
-   */
+  /// Set the contact filtering data. This is an expensive operation and should not be called
+  /// frequently. This will not update contacts until the next time step when either parent body is
+  /// awake. This automatically calls refilter.
+  ///
+  /// @param filter
   void setFilterData(final Filter filter) {
     _filter.set(filter);
 
     refilter();
   }
 
-  /**
-   * Get the contact filtering data.
-   *
-   * @return
-   */
+  /// Get the contact filtering data.
+  ///
+  /// @return
   Filter getFilterData() {
     return _filter;
   }
 
-  /**
-   * Call this if you want to establish collision that was previously disabled by
-   * ContactFilter::ShouldCollide.
-   */
+  /// Call this if you want to establish collision that was previously disabled by
+  /// ContactFilter::ShouldCollide.
   void refilter() {
     if (_body == null) {
       return;
@@ -151,22 +131,18 @@ class Fixture {
     }
   }
 
-  /**
-   * Get the parent body of this fixture. This is NULL if the fixture is not attached.
-   *
-   * @return the parent body.
-   * @return
-   */
+  /// Get the parent body of this fixture. This is NULL if the fixture is not attached.
+  ///
+  /// @return the parent body.
+  /// @return
   Body getBody() {
     return _body;
   }
 
-  /**
-   * Get the next fixture in the parent body's fixture list.
-   *
-   * @return the next shape.
-   * @return
-   */
+  /// Get the next fixture in the parent body's fixture list.
+  ///
+  /// @return the next shape.
+  /// @return
   Fixture getNext() {
     return _next;
   }
@@ -180,92 +156,72 @@ class Fixture {
     return _density;
   }
 
-  /**
-   * Test a point for containment in this fixture. This only works for convex shapes.
-   *
-   * @param p a point in world coordinates.
-   * @return
-   */
+  /// Test a point for containment in this fixture. This only works for convex shapes.
+  ///
+  /// @param p a point in world coordinates.
+  /// @return
   bool testPoint(final Vector2 p) {
     return _shape.testPoint(_body._transform, p);
   }
 
-  /**
-   * Cast a ray against this shape.
-   *
-   * @param output the ray-cast results.
-   * @param input the ray-cast input parameters.
-   * @param output
-   * @param input
-   */
+  /// Cast a ray against this shape.
+  ///
+  /// @param input the ray-cast input parameters.
+  /// @param output the ray-cast results.
   bool raycast(RayCastOutput output, RayCastInput input, int childIndex) {
     return _shape.raycast(output, input, _body._transform, childIndex);
   }
 
-  /**
-   * Get the mass data for this fixture. The mass data is based on the density and the shape. The
-   * rotational inertia is about the shape's origin.
-   *
-   * @return
-   */
+  /// Get the mass data for this fixture. The mass data is based on the density and the shape. The
+  /// rotational inertia is about the shape's origin.
+  ///
+  /// @return
   void getMassData(MassData massData) {
     _shape.computeMass(massData, _density);
   }
 
-  /**
-   * Get the coefficient of friction.
-   *
-   * @return
-   */
+  /// Get the coefficient of friction.
+  ///
+  /// @return
   double getFriction() {
     return _friction;
   }
 
-  /**
-   * Set the coefficient of friction. This will _not_ change the friction of existing contacts.
-   *
-   * @param friction
-   */
+  /// Set the coefficient of friction. This will _not_ change the friction of existing contacts.
+  ///
+  /// @param friction
   void setFriction(double friction) {
     _friction = friction;
   }
 
-  /**
-   * Get the coefficient of restitution.
-   *
-   * @return
-   */
+  /// Get the coefficient of restitution.
+  ///
+  /// @return
   double getRestitution() {
     return _restitution;
   }
 
-  /**
-   * Set the coefficient of restitution. This will _not_ change the restitution of existing
-   * contacts.
-   *
-   * @param restitution
-   */
+  /// Set the coefficient of restitution. This will _not_ change the restitution of existing
+  /// contacts.
+  ///
+  /// @param restitution
   void setRestitution(double restitution) {
     _restitution = restitution;
   }
 
-  /**
-   * Get the fixture's AABB. This AABB may be enlarge and/or stale. If you need a more accurate
-   * AABB, compute it using the shape and the body transform.
-   *
-   * @return
-   */
+  /// Get the fixture's AABB. This AABB may be enlarge and/or stale. If you need a more accurate
+  /// AABB, compute it using the shape and the body transform.
+  ///
+  /// @return
   AABB getAABB(int childIndex) {
     assert(childIndex >= 0 && childIndex < _proxyCount);
     return _proxies[childIndex].aabb;
   }
 
-  /**
-   * Compute the distance from this fixture.
-   *
-   * @param p a point in world coordinates.
-   * @return distance
-   */
+  /// Compute the distance from this fixture.
+  ///
+  /// @param p a point in world coordinates.
+  /// @return distance
   double computeDistance(Vector2 p, int childIndex, Vector2 normalOut) {
     return _shape.computeDistanceToOut(
         _body._transform, p, childIndex, normalOut);
@@ -346,11 +302,9 @@ class Fixture {
     }
   }
 
-  /**
-   * Internal method
-   *
-   * @param broadPhase
-   */
+  /// Internal method
+  ///
+  /// @param broadPhase
   void destroyProxies(BroadPhase broadPhase) {
     // Destroy proxies in the broad-phase.
     for (int i = 0; i < _proxyCount; ++i) {
@@ -366,13 +320,11 @@ class Fixture {
   final AABB _pool2 = new AABB();
   final Vector2 _displacement = new Vector2.zero();
 
-  /**
-   * Internal method
-   *
-   * @param broadPhase
-   * @param xf1
-   * @param xf2
-   */
+  /// Internal method
+  ///
+  /// @param broadPhase
+  /// @param xf1
+  /// @param xf2
   void synchronize(BroadPhase broadPhase, final Transform transform1,
       final Transform transform2) {
     if (_proxyCount == 0) {

--- a/lib/src/dynamics/fixture_def.dart
+++ b/lib/src/dynamics/fixture_def.dart
@@ -1,152 +1,112 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A fixture definition is used to create a fixture. This class defines an abstract fixture
- * definition. You can reuse fixture definitions safely.
- */
+/// A fixture definition is used to create a fixture. This class defines an abstract fixture
+/// definition. You can reuse fixture definitions safely.
 class FixtureDef {
-  /**
-   * The shape, this must be set. The shape will be cloned, so you can create the shape on the
-   * stack.
-   */
+  /// The shape, this must be set. The shape will be cloned, so you can create the shape on the
+  /// stack.
   Shape shape = null;
 
-  /**
-   * Use this to store application specific fixture data.
-   */
+  /// Use this to store application specific fixture data.
   Object userData;
 
-  /**
-   * The friction coefficient, usually in the range [0,1].
-   */
+  /// The friction coefficient, usually in the range [0,1].
   double friction = 0.2;
 
-  /**
-   * The restitution (elasticity) usually in the range [0,1].
-   */
+  /// The restitution (elasticity) usually in the range [0,1].
   double restitution = 0.0;
 
-  /**
-   * The density, usually in kg/m^2
-   */
+  /// The density, usually in kg/m^2
   double density = 0.0;
 
-  /**
-   * A sensor shape collects contact information but never generates a collision response.
-   */
+  /// A sensor shape collects contact information but never generates a collision response.
   bool isSensor = false;
 
-  /**
-   * Contact filtering data;
-   */
+  /// Contact filtering data;
   Filter filter = new Filter();
 
-  /**
-   * The shape, this must be set. The shape will be cloned, so you can create the shape on the
-   * stack.
-   */
+  /// The shape, this must be set. The shape will be cloned, so you can create the shape on the
+  /// stack.
   Shape getShape() {
     return shape;
   }
 
-  /**
-   * The shape, this must be set. The shape will be cloned, so you can create the shape on the
-   * stack.
-   */
+  /// The shape, this must be set. The shape will be cloned, so you can create the shape on the
+  /// stack.
   void setShape(Shape shape) {
     this.shape = shape;
   }
 
-  /**
-   * Use this to store application specific fixture data.
-   */
+  /// Use this to store application specific fixture data.
   Object getUserData() {
     return userData;
   }
 
-  /**
-   * Use this to store application specific fixture data.
-   */
+  /// Use this to store application specific fixture data.
   void setUserData(Object userData) {
     this.userData = userData;
   }
 
-  /**
-   * The friction coefficient, usually in the range [0,1].
-   */
+  /// The friction coefficient, usually in the range [0,1].
   double getFriction() {
     return friction;
   }
 
-  /**
-   * The friction coefficient, usually in the range [0,1].
-   */
+  /// The friction coefficient, usually in the range [0,1].
   void setFriction(double friction) {
     this.friction = friction;
   }
 
-  /**
-   * The restitution (elasticity) usually in the range [0,1].
-   */
+  /// The restitution (elasticity) usually in the range [0,1].
   double getRestitution() {
     return restitution;
   }
 
-  /**
-   * The restitution (elasticity) usually in the range [0,1].
-   */
+  /// The restitution (elasticity) usually in the range [0,1].
   void setRestitution(double restitution) {
     this.restitution = restitution;
   }
 
-  /**
-   * The density, usually in kg/m^2
-   */
+  /// The density, usually in kg/m^2
   double getDensity() {
     return density;
   }
 
-  /**
-   * The density, usually in kg/m^2
-   */
+  /// The density, usually in kg/m^2
   void setDensity(double density) {
     this.density = density;
   }
 
-  /**
-   * Contact filtering data;
-   */
+  /// Contact filtering data;
   Filter getFilter() {
     return filter;
   }
 
-  /**
-   * Contact filtering data;
-   */
+  /// Contact filtering data;
   void setFilter(Filter filter) {
     this.filter = filter;
   }

--- a/lib/src/dynamics/fixture_proxy.dart
+++ b/lib/src/dynamics/fixture_proxy.dart
@@ -24,9 +24,7 @@
 
 part of box2d;
 
-/**
- * This proxy is used internally to connect fixtures to the broad-phase.
- */
+/// This proxy is used internally to connect fixtures to the broad-phase.
 class FixtureProxy {
   final AABB aabb = new AABB();
   Fixture fixture;

--- a/lib/src/dynamics/island.dart
+++ b/lib/src/dynamics/island.dart
@@ -368,7 +368,7 @@ class Island {
     report(_contactSolver._velocityConstraints);
 
     if (allowSleep) {
-      double minSleepTime = double.MAX_FINITE;
+      double minSleepTime = double.maxFinite;
 
       final double linTolSqr =
           Settings.linearSleepTolerance * Settings.linearSleepTolerance;

--- a/lib/src/dynamics/island.dart
+++ b/lib/src/dynamics/island.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -142,9 +142,7 @@ part of box2d;
  However, we can compute sin+cos of the same angle fast.
  */
 
-/**
- * This is an internal class.
- */
+/// This is an internal class.
 class Island {
   ContactListener _listener;
 

--- a/lib/src/dynamics/joints/constant_volume_joints.dart
+++ b/lib/src/dynamics/joints/constant_volume_joints.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -230,16 +230,16 @@ class ConstantVolumeJoint extends Joint {
     }
   }
 
-  /** No-op */
+  /// No-op
   void getAnchorA(Vector2 argOut) {}
 
-  /** No-op */
+  /// No-op
   void getAnchorB(Vector2 argOut) {}
 
-  /** No-op */
+  /// No-op
   void getReactionForce(double inv_dt, Vector2 argOut) {}
 
-  /** No-op */
+  /// No-op
   double getReactionTorque(double inv_dt) {
     return 0.0;
   }

--- a/lib/src/dynamics/joints/constant_volume_joints_def.dart
+++ b/lib/src/dynamics/joints/constant_volume_joints_def.dart
@@ -24,10 +24,8 @@
 
 part of box2d;
 
-/**
- * Definition for a {@link ConstantVolumeJoint}, which connects a group a bodies together so they
- * maintain a constant volume within them.
- */
+/// Definition for a {@link ConstantVolumeJoint}, which connects a group a bodies together so they
+/// maintain a constant volume within them.
 
 class ConstantVolumeJointDef extends JointDef {
   double frequencyHz = 0.0;
@@ -40,11 +38,9 @@ class ConstantVolumeJointDef extends JointDef {
     collideConnected = false;
   }
 
-  /**
-   * Adds a body to the group
-   * 
-   * @param argBody
-   */
+  /// Adds a body to the group
+  ///
+  /// @param argBody
   void addBody(Body argBody) {
     bodies.add(argBody);
     if (bodies.length == 1) {
@@ -55,9 +51,7 @@ class ConstantVolumeJointDef extends JointDef {
     }
   }
 
-  /**
-   * Adds a body and the pre-made distance joint. Should only be used for deserialization.
-   */
+  /// Adds a body and the pre-made distance joint. Should only be used for deserialization.
   void addBodyAndJoint(Body argBody, DistanceJoint argJoint) {
     addBody(argBody);
     if (joints == null) {

--- a/lib/src/dynamics/joints/distance_joint.dart
+++ b/lib/src/dynamics/joints/distance_joint.dart
@@ -165,7 +165,7 @@ class DistanceJoint extends Joint {
       double C = length - _length;
 
       // Frequency
-      double omega = 2.0 * Math.PI * _frequencyHz;
+      double omega = 2.0 * Math.pi * _frequencyHz;
 
       // Damping coefficient
       double d = 2.0 * _mass * _dampingRatio * omega;

--- a/lib/src/dynamics/joints/distance_joint.dart
+++ b/lib/src/dynamics/joints/distance_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -31,10 +31,8 @@ part of box2d;
 //K = J * invM * JT
 //= invMass1 + invI1 * cross(r1, u)^2 + invMass2 + invI2 * cross(r2, u)^2
 
-/**
- * A distance joint constrains two points on two bodies to remain at a fixed distance from each
- * other. You can view this as a massless, rigid rod.
- */
+/// A distance joint constrains two points on two bodies to remain at a fixed distance from each
+/// other. You can view this as a massless, rigid rod.
 
 class DistanceJoint extends Joint {
   double _frequencyHz = 0.0;
@@ -79,19 +77,15 @@ class DistanceJoint extends Joint {
     _bodyB.getWorldPointToOut(_localAnchorB, argOut);
   }
 
-  /**
-   * Get the reaction force given the inverse time step. Unit is N.
-   */
+  /// Get the reaction force given the inverse time step. Unit is N.
 
   void getReactionForce(double inv_dt, Vector2 argOut) {
     argOut.x = _impulse * _u.x * inv_dt;
     argOut.y = _impulse * _u.y * inv_dt;
   }
 
-  /**
-   * Get the reaction torque given the inverse time step. Unit is N*m. This is always zero for a
-   * distance joint.
-   */
+  /// Get the reaction torque given the inverse time step. Unit is N*m. This is always zero for a
+  /// distance joint.
 
   double getReactionTorque(double inv_dt) {
     return 0.0;

--- a/lib/src/dynamics/joints/distance_joint_def.dart
+++ b/lib/src/dynamics/joints/distance_joint_def.dart
@@ -24,44 +24,36 @@
 
 part of box2d;
 
-/**
- * Distance joint definition. This requires defining an anchor point on both bodies and the non-zero
- * length of the distance joint. The definition uses local anchor points so that the initial
- * configuration can violate the constraint slightly. This helps when saving and loading a game.
- * 
- * @warning Do not use a zero or short length.
- */
+/// Distance joint definition. This requires defining an anchor point on both bodies and the non-zero
+/// length of the distance joint. The definition uses local anchor points so that the initial
+/// configuration can violate the constraint slightly. This helps when saving and loading a game.
+///
+/// @warning Do not use a zero or short length.
 
 class DistanceJointDef extends JointDef {
-  /** The local anchor point relative to body1's origin. */
+  /// The local anchor point relative to body1's origin.
   final Vector2 localAnchorA = new Vector2.zero();
 
-  /** The local anchor point relative to body2's origin. */
+  /// The local anchor point relative to body2's origin.
   final Vector2 localAnchorB = new Vector2.zero();
 
-  /** The equilibrium length between the anchor points. */
+  /// The equilibrium length between the anchor points.
   double length = 1.0;
 
-  /**
-   * The mass-spring-damper frequency in Hertz.
-   */
+  /// The mass-spring-damper frequency in Hertz.
   double frequencyHz = 0.0;
 
-  /**
-   * The damping ratio. 0 = no damping, 1 = critical damping.
-   */
+  /// The damping ratio. 0 = no damping, 1 = critical damping.
   double dampingRatio = 0.0;
 
   DistanceJointDef() : super(JointType.DISTANCE);
 
-  /**
-   * Initialize the bodies, anchors, and length using the world anchors.
-   * 
-   * @param b1 First body
-   * @param b2 Second body
-   * @param anchor1 World anchor on first body
-   * @param anchor2 World anchor on second body
-   */
+  /// Initialize the bodies, anchors, and length using the world anchors.
+  ///
+  /// @param b1 First body
+  /// @param b2 Second body
+  /// @param anchor1 World anchor on first body
+  /// @param anchor2 World anchor on second body
   void initialize(final Body b1, final Body b2, final Vector2 anchor1,
       final Vector2 anchor2) {
     bodyA = b1;

--- a/lib/src/dynamics/joints/friction_joint.dart
+++ b/lib/src/dynamics/joints/friction_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -101,9 +101,7 @@ class FrictionJoint extends Joint {
     return _maxTorque;
   }
 
-  /**
-   * @see org.jbox2d.dynamics.joints.Joint#initVelocityConstraints(org.jbox2d.dynamics.TimeStep)
-   */
+  /// @see org.jbox2d.dynamics.joints.Joint#initVelocityConstraints(org.jbox2d.dynamics.TimeStep)
 
   void initVelocityConstraints(final SolverData data) {
     _indexA = _bodyA._islandIndex;

--- a/lib/src/dynamics/joints/friction_joint_def.dart
+++ b/lib/src/dynamics/joints/friction_joint_def.dart
@@ -1,53 +1,41 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * Friction joint definition.
- *
- * @author Daniel Murphy
- */
+/// Friction joint definition.
 class FrictionJointDef extends JointDef {
-  /**
-   * The local anchor point relative to bodyA's origin.
-   */
+  /// The local anchor point relative to bodyA's origin.
   final Vector2 localAnchorA;
 
-  /**
-   * The local anchor point relative to bodyB's origin.
-   */
+  /// The local anchor point relative to bodyB's origin.
   final Vector2 localAnchorB;
 
-  /**
-   * The maximum friction force in N.
-   */
+  /// The maximum friction force in N.
   double maxForce = 0.0;
 
-  /**
-   * The maximum friction torque in N-m.
-   */
+  /// The maximum friction torque in N-m.
   double maxTorque = 0.0;
 
   FrictionJointDef()
@@ -55,10 +43,8 @@ class FrictionJointDef extends JointDef {
         localAnchorB = new Vector2.zero(),
         super(JointType.FRICTION);
 
-  /**
-   * Initialize the bodies, anchors, axis, and reference angle using the world anchor and world
-   * axis.
-   */
+  /// Initialize the bodies, anchors, axis, and reference angle using the world anchor and world
+  /// axis.
   void initialize(Body bA, Body bB, Vector2 anchor) {
     bodyA = bA;
     bodyB = bB;

--- a/lib/src/dynamics/joints/gear_joint.dart
+++ b/lib/src/dynamics/joints/gear_joint.dart
@@ -68,13 +68,13 @@ class GearJoint extends Joint {
   final Body _bodyD;
 
   // Solver shared
-  final Vector2 _localAnchorA = new Vector2.zero();
-  final Vector2 _localAnchorB = new Vector2.zero();
-  final Vector2 _localAnchorC = new Vector2.zero();
-  final Vector2 _localAnchorD = new Vector2.zero();
+  final Vector2 _localAnchorA = Vector2.zero();
+  final Vector2 _localAnchorB = Vector2.zero();
+  final Vector2 _localAnchorC = Vector2.zero();
+  final Vector2 _localAnchorD = Vector2.zero();
 
-  final Vector2 _localAxisC = new Vector2.zero();
-  final Vector2 _localAxisD = new Vector2.zero();
+  final Vector2 _localAxisC = Vector2.zero();
+  final Vector2 _localAxisD = Vector2.zero();
 
   double _referenceAngleA = 0.0;
   double _referenceAngleB = 0.0;
@@ -86,13 +86,13 @@ class GearJoint extends Joint {
 
   // Solver temp
   int _indexA = 0, _indexB = 0, _indexC = 0, _indexD = 0;
-  final Vector2 _lcA = new Vector2.zero(),
-      _lcB = new Vector2.zero(),
-      _lcC = new Vector2.zero(),
-      _lcD = new Vector2.zero();
+  final Vector2 _lcA = Vector2.zero(),
+      _lcB = Vector2.zero(),
+      _lcC = Vector2.zero(),
+      _lcD = Vector2.zero();
   double _mA = 0.0, _mB = 0.0, _mC = 0.0, _mD = 0.0;
   double _iA = 0.0, _iB = 0.0, _iC = 0.0, _iD = 0.0;
-  final Vector2 _JvAC = new Vector2.zero(), _JvBD = new Vector2.zero();
+  final Vector2 _JvAC = Vector2.zero(), _JvBD = Vector2.zero();
   double _JwA = 0.0, _JwB = 0.0, _JwC = 0.0, _JwD = 0.0;
   double _mass = 0.0;
 

--- a/lib/src/dynamics/joints/gear_joint.dart
+++ b/lib/src/dynamics/joints/gear_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -43,18 +43,14 @@ part of box2d;
 //J = [ug cross(r, ug)]
 //K = J * invM * JT = invMass + invI * cross(r, ug)^2
 
-/**
- * A gear joint is used to connect two joints together. Either joint can be a revolute or prismatic
- * joint. You specify a gear ratio to bind the motions together: coordinate1 + ratio * coordinate2 =
- * constant The ratio can be negative or positive. If one joint is a revolute joint and the other
- * joint is a prismatic joint, then the ratio will have units of length or units of 1/length.
- *
- * @warning The revolute and prismatic joints must be attached to fixed bodies (which must be body1
- *          on those joints).
- * @warning You have to manually destroy the gear joint if joint1 or joint2 is destroyed.
- * @author Daniel Murphy
- */
-
+/// A gear joint is used to connect two joints together. Either joint can be a revolute or prismatic
+/// joint. You specify a gear ratio to bind the motions together: coordinate1 + ratio * coordinate2 =
+/// constant The ratio can be negative or positive. If one joint is a revolute joint and the other
+/// joint is a prismatic joint, then the ratio will have units of length or units of 1/length.
+///
+/// @warning The revolute and prismatic joints must be attached to fixed bodies (which must be body1
+///          on those joints).
+/// @warning You have to manually destroy the gear joint if joint1 or joint2 is destroyed.
 class GearJoint extends Joint {
   final Joint _joint1;
   final Joint _joint2;

--- a/lib/src/dynamics/joints/gear_joint_def.dart
+++ b/lib/src/dynamics/joints/gear_joint_def.dart
@@ -24,29 +24,18 @@
 
 part of box2d;
 
-/**
- * Gear joint definition. This definition requires two existing revolute or prismatic joints (any
- * combination will work). The provided joints must attach a dynamic body to a static body.
- * 
- * @author Daniel Murphy
- */
-
+/// Gear joint definition. This definition requires two existing revolute or prismatic joints (any
+/// combination will work). The provided joints must attach a dynamic body to a static body.
 class GearJointDef extends JointDef {
-  /**
-   * The first revolute/prismatic joint attached to the gear joint.
-   */
+  /// The first revolute/prismatic joint attached to the gear joint.
   Joint joint1;
 
-  /**
-   * The second revolute/prismatic joint attached to the gear joint.
-   */
+  /// The second revolute/prismatic joint attached to the gear joint.
   Joint joint2;
 
-  /**
-   * Gear ratio.
-   * 
-   * @see GearJoint
-   */
+  /// Gear ratio.
+  ///
+  /// @see GearJoint
   double ratio = 0.0;
 
   GearJointDef() : super(JointType.GEAR);

--- a/lib/src/dynamics/joints/joint.dart
+++ b/lib/src/dynamics/joints/joint.dart
@@ -24,15 +24,10 @@
 
 part of box2d;
 
-/**
- * The base joint class. Joints are used to constrain two bodies together in various fashions. Some
- * joints also feature limits and motors.
- * 
- * @author Daniel Murphy
- */
+/// The base joint class. Joints are used to constrain two bodies together in various fashions. Some
+/// joints also feature limits and motors.
 abstract class Joint {
   static Joint create(World world, JointDef def) {
-    // Joint joint = null;
     switch (def.type) {
       case JointType.MOUSE:
         return new MouseJoint(world.getPool(), def as MouseJointDef);
@@ -79,14 +74,7 @@ abstract class Joint {
   bool _islandFlag = false;
   bool _collideConnected = false;
 
-  Object _userData;
-
   IWorldPool pool;
-
-  // Cache here per time step to reduce cache misses.
-  // final Vec2 _localCenterA, _localCenterB;
-  // double _invMassA, _invIA;
-  // double _invMassB, _invIB;
 
   Joint(IWorldPool worldPool, JointDef def) : _type = def.type {
     assert(def.bodyA != def.bodyB);
@@ -98,7 +86,6 @@ abstract class Joint {
     _bodyB = def.bodyB;
     _collideConnected = def.collideConnected;
     _islandFlag = false;
-    _userData = def.userData;
 
     _edgeA = new JointEdge();
     _edgeA.joint = null;
@@ -111,103 +98,76 @@ abstract class Joint {
     _edgeB.other = null;
     _edgeB.prev = null;
     _edgeB.next = null;
-
-    // _localCenterA = new Vec2();
-    // _localCenterB = new Vec2();
   }
 
-  /**
-   * get the type of the concrete joint.
-   * 
-   * @return
-   */
+  /// get the type of the concrete joint.
+  ///
+  /// @return
   JointType getType() {
     return _type;
   }
 
-  /**
-   * get the first body attached to this joint.
-   */
+  /// get the first body attached to this joint.
   Body getBodyA() {
     return _bodyA;
   }
 
-  /**
-   * get the second body attached to this joint.
-   * 
-   * @return
-   */
+  /// get the second body attached to this joint.
+  ///
+  /// @return
   Body getBodyB() {
     return _bodyB;
   }
 
-  /**
-   * get the anchor point on bodyA in world coordinates.
-   * 
-   * @return
-   */
+  /// get the anchor point on bodyA in world coordinates.
+  ///
+  /// @return
   void getAnchorA(Vector2 out);
 
-  /**
-   * get the anchor point on bodyB in world coordinates.
-   * 
-   * @return
-   */
+  /// get the anchor point on bodyB in world coordinates.
+  ///
+  /// @return
   void getAnchorB(Vector2 out);
 
-  /**
-   * get the reaction force on body2 at the joint anchor in Newtons.
-   * 
-   * @param inv_dt
-   * @return
-   */
+  /// get the reaction force on body2 at the joint anchor in Newtons.
+  ///
+  /// @param inv_dt
+  /// @return
   void getReactionForce(double inv_dt, Vector2 out);
 
-  /**
-   * get the reaction torque on body2 in N*m.
-   * 
-   * @param inv_dt
-   * @return
-   */
+  /// get the reaction torque on body2 in N*m.
+  ///
+  /// @param inv_dt
+  /// @return
   double getReactionTorque(double inv_dt);
 
-  /**
-   * get the next joint the world joint list.
-   */
+  /// get the next joint the world joint list.
   Joint getNext() {
     return _next;
   }
 
-  /**
-   * Get collide connected. Note: modifying the collide connect flag won't work correctly because
-   * the flag is only checked when fixture AABBs begin to overlap.
-   */
+  /// Get collide connected. Note: modifying the collide connect flag won't work correctly because
+  /// the flag is only checked when fixture AABBs begin to overlap.
   bool getCollideConnected() {
     return _collideConnected;
   }
 
-  /**
-   * Short-cut function to determine if either body is inactive.
-   * 
-   * @return
-   */
+  /// Short-cut function to determine if either body is inactive.
+  ///
+  /// @return
   bool isActive() {
     return _bodyA.isActive() && _bodyB.isActive();
   }
 
-  /** Internal */
+  /// Internal
   void initVelocityConstraints(SolverData data);
 
-  /** Internal */
+  /// Internal
   void solveVelocityConstraints(SolverData data);
 
-  /**
-   * This returns true if the position errors are within tolerance. Internal.
-   */
+  /// This returns true if the position errors are within tolerance. Internal.
   bool solvePositionConstraints(SolverData data);
 
-  /**
-   * Override to handle destruction of joint
-   */
+  /// Override to handle destruction of joint
   void destructor() {}
 }

--- a/lib/src/dynamics/joints/joint_def.dart
+++ b/lib/src/dynamics/joints/joint_def.dart
@@ -24,37 +24,25 @@
 
 part of box2d;
 
-/**
- * Joint definitions are used to construct joints.
- * @author Daniel Murphy
- */
+/// Joint definitions are used to construct joints.
 class JointDef {
   JointDef(JointType type) {
     this.type = type;
     collideConnected = false;
   }
-  /**
-   * The joint type is set automatically for concrete joint types.
-   */
+
+  /// The joint type is set automatically for concrete joint types.
   JointType type;
 
-  /**
-   * Use this to attach application specific data to your joints.
-   */
+  /// Use this to attach application specific data to your joints.
   Object userData;
 
-  /**
-   * The first attached body.
-   */
+  /// The first attached body.
   Body bodyA;
 
-  /**
-   * The second attached body.
-   */
+  /// The second attached body.
   Body bodyB;
 
-  /**
-   * Set this flag to true if the attached bodies should collide.
-   */
+  /// Set this flag to true if the attached bodies should collide.
   bool collideConnected = false;
 }

--- a/lib/src/dynamics/joints/joint_edge.dart
+++ b/lib/src/dynamics/joints/joint_edge.dart
@@ -24,32 +24,21 @@
 
 part of box2d;
 
-/**
- * A joint edge is used to connect bodies and joints together
- * in a joint graph where each body is a node and each joint
- * is an edge. A joint edge belongs to a doubly linked list
- * maintained in each attached body. Each joint has two joint
- * nodes, one for each attached body.
- * @author Daniel
- */
+/// A joint edge is used to connect bodies and joints together
+/// in a joint graph where each body is a node and each joint
+/// is an edge. A joint edge belongs to a doubly linked list
+/// maintained in each attached body. Each joint has two joint
+/// nodes, one for each attached body.
 class JointEdge {
-  /**
-   * Provides quick access to the other body attached
-   */
+  /// Provides quick access to the other body attached
   Body other = null;
 
-  /**
-   * the joint
-   */
+  /// the joint
   Joint joint = null;
 
-  /**
-   * the previous joint edge in the body's joint list
-   */
+  /// the previous joint edge in the body's joint list
   JointEdge prev = null;
 
-  /**
-   * the next joint edge in the body's joint list
-   */
+  /// the next joint edge in the body's joint list
   JointEdge next = null;
 }

--- a/lib/src/dynamics/joints/motor_joint.dart
+++ b/lib/src/dynamics/joints/motor_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -36,12 +36,8 @@ part of box2d;
 //J = [0 0 -1 0 0 1]
 //K = invI1 + invI2
 
-/**
- * A motor joint is used to control the relative motion between two bodies. A typical usage is to
- * control the movement of a dynamic body with respect to the ground.
- *
- * @author dmurph
- */
+/// A motor joint is used to control the relative motion between two bodies. A typical usage is to
+/// control the movement of a dynamic body with respect to the ground.
 class MotorJoint extends Joint {
   // Solver shared
   final Vector2 _linearOffset = new Vector2.zero();
@@ -97,9 +93,7 @@ class MotorJoint extends Joint {
     return _angularImpulse * inv_dt;
   }
 
-  /**
-   * Set the target linear offset, in frame A, in meters.
-   */
+  /// Set the target linear offset, in frame A, in meters.
   void setLinearOffset(Vector2 linearOffset) {
     if (linearOffset.x != _linearOffset.x ||
         linearOffset.y != _linearOffset.y) {
@@ -109,25 +103,19 @@ class MotorJoint extends Joint {
     }
   }
 
-  /**
-   * Get the target linear offset, in frame A, in meters.
-   */
+  /// Get the target linear offset, in frame A, in meters.
   void getLinearOffsetOut(Vector2 out) {
     out.setFrom(_linearOffset);
   }
 
-  /**
-   * Get the target linear offset, in frame A, in meters. Do not modify.
-   */
+  /// Get the target linear offset, in frame A, in meters. Do not modify.
   Vector2 getLinearOffset() {
     return _linearOffset;
   }
 
-  /**
-   * Set the target angular offset, in radians.
-   *
-   * @param angularOffset
-   */
+  /// Set the target angular offset, in radians.
+  ///
+  /// @param angularOffset
   void setAngularOffset(double angularOffset) {
     if (angularOffset != _angularOffset) {
       _bodyA.setAwake(true);
@@ -140,34 +128,26 @@ class MotorJoint extends Joint {
     return _angularOffset;
   }
 
-  /**
-   * Set the maximum friction force in N.
-   *
-   * @param force
-   */
+  /// Set the maximum friction force in N.
+  ///
+  /// @param force
   void setMaxForce(double force) {
     assert(force >= 0.0);
     _maxForce = force;
   }
 
-  /**
-   * Get the maximum friction force in N.
-   */
+  /// Get the maximum friction force in N.
   double getMaxForce() {
     return _maxForce;
   }
 
-  /**
-   * Set the maximum friction torque in N*m.
-   */
+  /// Set the maximum friction torque in N*m.
   void setMaxTorque(double torque) {
     assert(torque >= 0.0);
     _maxTorque = torque;
   }
 
-  /**
-   * Get the maximum friction torque in N*m.
-   */
+  /// Get the maximum friction torque in N*m.
   double getMaxTorque() {
     return _maxTorque;
   }

--- a/lib/src/dynamics/joints/motor_joint_def.dart
+++ b/lib/src/dynamics/joints/motor_joint_def.dart
@@ -1,58 +1,44 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * Motor joint definition.
- *
- * @author dmurph
- */
+/// Motor joint definition.
 class MotorJointDef extends JointDef {
-  /**
-   * Position of bodyB minus the position of bodyA, in bodyA's frame, in meters.
-   */
+  /// Position of bodyB minus the position of bodyA, in bodyA's frame, in meters.
   final Vector2 linearOffset = new Vector2.zero();
 
-  /**
-   * The bodyB angle minus bodyA angle in radians.
-   */
+  /// The bodyB angle minus bodyA angle in radians.
   double angularOffset = 0.0;
 
-  /**
-   * The maximum motor force in N.
-   */
+  /// The maximum motor force in N.
   double maxForce = 1.0;
 
-  /**
-   * The maximum motor torque in N-m.
-   */
+  /// The maximum motor torque in N-m.
   double maxTorque = 1.0;
 
-  /**
-   * Position correction factor in the range [0,1].
-   */
+  /// Position correction factor in the range [0,1].
   double correctionFactor = 0.3;
 
   MotorJointDef() : super(JointType.MOTOR);

--- a/lib/src/dynamics/joints/mouse_joint.dart
+++ b/lib/src/dynamics/joints/mouse_joint.dart
@@ -117,7 +117,7 @@ class MouseJoint extends Joint {
     double mass = _bodyB.mass;
 
     // Frequency
-    double omega = 2.0 * Math.PI * _frequencyHz;
+    double omega = 2.0 * Math.pi * _frequencyHz;
 
     // Damping coefficient
     double d = 2.0 * mass * _dampingRatio * omega;

--- a/lib/src/dynamics/joints/mouse_joint.dart
+++ b/lib/src/dynamics/joints/mouse_joint.dart
@@ -1,37 +1,33 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A mouse joint is used to make a point on a body track a specified world point. This a soft
- * constraint with a maximum force. This allows the constraint to stretch and without applying huge
- * forces. NOTE: this joint is not documented in the manual because it was developed to be used in
- * the testbed. If you want to learn how to use the mouse joint, look at the testbed.
- *
- * @author Daniel
- */
+/// A mouse joint is used to make a point on a body track a specified world point. This a soft
+/// constraint with a maximum force. This allows the constraint to stretch and without applying huge
+/// forces. NOTE: this joint is not documented in the manual because it was developed to be used in
+/// the testbed. If you want to learn how to use the mouse joint, look at the testbed.
 class MouseJoint extends Joint {
   final Vector2 _localAnchorB = new Vector2.zero();
   final Vector2 _targetA = new Vector2.zero();

--- a/lib/src/dynamics/joints/mouse_joint_def.dart
+++ b/lib/src/dynamics/joints/mouse_joint_def.dart
@@ -24,31 +24,19 @@
 
 part of box2d;
 
-/**
- * Mouse joint definition. This requires a world target point, tuning parameters, and the time step.
- * 
- * @author Daniel
- */
+/// Mouse joint definition. This requires a world target point, tuning parameters, and the time step.
 class MouseJointDef extends JointDef {
-  /**
-   * The initial world target point. This is assumed to coincide with the body anchor initially.
-   */
+  /// The initial world target point. This is assumed to coincide with the body anchor initially.
   final Vector2 target = new Vector2.zero();
 
-  /**
-   * The maximum constraint force that can be exerted to move the candidate body. Usually you will
-   * express as some multiple of the weight (multiplier * mass * gravity).
-   */
+  /// The maximum constraint force that can be exerted to move the candidate body. Usually you will
+  /// express as some multiple of the weight (multiplier * mass * gravity).
   double maxForce = 0.0;
 
-  /**
-   * The response speed.
-   */
+  /// The response speed.
   double frequencyHz = 5.0;
 
-  /**
-   * The damping ratio. 0 = no damping, 1 = critical damping.
-   */
+  /// The damping ratio. 0 = no damping, 1 = critical damping.
   double dampingRatio = .7;
 
   MouseJointDef() : super(JointType.MOUSE);

--- a/lib/src/dynamics/joints/prismatic_joint.dart
+++ b/lib/src/dynamics/joints/prismatic_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -90,13 +90,9 @@ part of box2d;
 //Now compute impulse to be applied:
 //df = f2 - f1
 
-/**
- * A prismatic joint. This joint provides one degree of freedom: translation along an axis fixed in
- * bodyA. Relative rotation is prevented. You can use a joint limit to restrict the range of motion
- * and a joint motor to drive the motion or to model joint friction.
- *
- * @author Daniel
- */
+/// A prismatic joint. This joint provides one degree of freedom: translation along an axis fixed in
+/// bodyA. Relative rotation is prevented. You can use a joint limit to restrict the range of motion
+/// and a joint motor to drive the motion or to model joint friction.
 class PrismaticJoint extends Joint {
   // Solver shared
   final Vector2 _localAnchorA;
@@ -184,9 +180,7 @@ class PrismaticJoint extends Joint {
     return inv_dt * _impulse.y;
   }
 
-  /**
-   * Get the current joint translation, usually in meters.
-   */
+  /// Get the current joint translation, usually in meters.
   double getJointSpeed() {
     Body bA = _bodyA;
     Body bB = _bodyB;
@@ -254,20 +248,16 @@ class PrismaticJoint extends Joint {
     return translation;
   }
 
-  /**
-   * Is the joint limit enabled?
-   *
-   * @return
-   */
+  /// Is the joint limit enabled?
+  ///
+  /// @return
   bool isLimitEnabled() {
     return _enableLimit;
   }
 
-  /**
-   * Enable/disable the joint limit.
-   *
-   * @param flag
-   */
+  /// Enable/disable the joint limit.
+  ///
+  /// @param flag
   void enableLimit(bool flag) {
     if (flag != _enableLimit) {
       _bodyA.setAwake(true);
@@ -277,30 +267,24 @@ class PrismaticJoint extends Joint {
     }
   }
 
-  /**
-   * Get the lower joint limit, usually in meters.
-   *
-   * @return
-   */
+  /// Get the lower joint limit, usually in meters.
+  ///
+  /// @return
   double getLowerLimit() {
     return _lowerTranslation;
   }
 
-  /**
-   * Get the upper joint limit, usually in meters.
-   *
-   * @return
-   */
+  /// Get the upper joint limit, usually in meters.
+  ///
+  /// @return
   double getUpperLimit() {
     return _upperTranslation;
   }
 
-  /**
-   * Set the joint limits, usually in meters.
-   *
-   * @param lower
-   * @param upper
-   */
+  /// Set the joint limits, usually in meters.
+  ///
+  /// @param lower
+  /// @param upper
   void setLimits(double lower, double upper) {
     assert(lower <= upper);
     if (lower != _lowerTranslation || upper != _upperTranslation) {
@@ -312,63 +296,51 @@ class PrismaticJoint extends Joint {
     }
   }
 
-  /**
-   * Is the joint motor enabled?
-   *
-   * @return
-   */
+  /// Is the joint motor enabled?
+  ///
+  /// @return
   bool isMotorEnabled() {
     return _enableMotor;
   }
 
-  /**
-   * Enable/disable the joint motor.
-   *
-   * @param flag
-   */
+  /// Enable/disable the joint motor.
+  ///
+  /// @param flag
   void enableMotor(bool flag) {
     _bodyA.setAwake(true);
     _bodyB.setAwake(true);
     _enableMotor = flag;
   }
 
-  /**
-   * Set the motor speed, usually in meters per second.
-   *
-   * @param speed
-   */
+  /// Set the motor speed, usually in meters per second.
+  ///
+  /// @param speed
   void setMotorSpeed(double speed) {
     _bodyA.setAwake(true);
     _bodyB.setAwake(true);
     _motorSpeed = speed;
   }
 
-  /**
-   * Get the motor speed, usually in meters per second.
-   *
-   * @return
-   */
+  /// Get the motor speed, usually in meters per second.
+  ///
+  /// @return
   double getMotorSpeed() {
     return _motorSpeed;
   }
 
-  /**
-   * Set the maximum motor force, usually in N.
-   *
-   * @param force
-   */
+  /// Set the maximum motor force, usually in N.
+  ///
+  /// @param force
   void setMaxMotorForce(double force) {
     _bodyA.setAwake(true);
     _bodyB.setAwake(true);
     _maxMotorForce = force;
   }
 
-  /**
-   * Get the current motor force, usually in N.
-   *
-   * @param inv_dt
-   * @return
-   */
+  /// Get the current motor force, usually in N.
+  ///
+  /// @param inv_dt
+  /// @return
   double getMotorForce(double inv_dt) {
     return _motorImpulse * inv_dt;
   }

--- a/lib/src/dynamics/joints/prismatic_joint_def.dart
+++ b/lib/src/dynamics/joints/prismatic_joint_def.dart
@@ -24,74 +24,48 @@
 
 part of box2d;
 
-/**
- * Prismatic joint definition. This requires defining a line of motion using an axis and an anchor
- * point. The definition uses local anchor points and a local axis so that the initial configuration
- * can violate the constraint slightly. The joint translation is zero when the local anchor points
- * coincide in world space. Using local anchors and a local axis helps when saving and loading a
- * game.
- * 
- * @warning at least one body should by dynamic with a non-fixed rotation.
- * @author Daniel
- * 
- */
+/// Prismatic joint definition. This requires defining a line of motion using an axis and an anchor
+/// point. The definition uses local anchor points and a local axis so that the initial configuration
+/// can violate the constraint slightly. The joint translation is zero when the local anchor points
+/// coincide in world space. Using local anchors and a local axis helps when saving and loading a
+/// game.
+///
+/// @warning at least one body should by dynamic with a non-fixed rotation.
 class PrismaticJointDef extends JointDef {
-  /**
-   * The local anchor point relative to body1's origin.
-   */
+  /// The local anchor point relative to body1's origin.
   final Vector2 localAnchorA = new Vector2.zero();
 
-  /**
-   * The local anchor point relative to body2's origin.
-   */
+  /// The local anchor point relative to body2's origin.
   final Vector2 localAnchorB = new Vector2.zero();
 
-  /**
-   * The local translation axis in body1.
-   */
+  /// The local translation axis in body1.
   final Vector2 localAxisA = new Vector2(1.0, 0.0);
 
-  /**
-   * The constrained angle between the bodies: body2_angle - body1_angle.
-   */
+  /// The constrained angle between the bodies: body2_angle - body1_angle.
   double referenceAngle = 0.0;
 
-  /**
-   * Enable/disable the joint limit.
-   */
+  /// Enable/disable the joint limit.
   bool enableLimit = false;
 
-  /**
-   * The lower translation limit, usually in meters.
-   */
+  /// The lower translation limit, usually in meters.
   double lowerTranslation = 0.0;
 
-  /**
-   * The upper translation limit, usually in meters.
-   */
+  /// The upper translation limit, usually in meters.
   double upperTranslation = 0.0;
 
-  /**
-   * Enable/disable the joint motor.
-   */
+  /// Enable/disable the joint motor.
   bool enableMotor = false;
 
-  /**
-   * The maximum motor torque, usually in N-m.
-   */
+  /// The maximum motor torque, usually in N-m.
   double maxMotorForce = 0.0;
 
-  /**
-   * The desired motor speed in radians per second.
-   */
+  /// The desired motor speed in radians per second.
   double motorSpeed = 0.0;
 
   PrismaticJointDef() : super(JointType.PRISMATIC);
 
-  /**
-   * Initialize the bodies, anchors, axis, and reference angle using the world anchor and world
-   * axis.
-   */
+  /// Initialize the bodies, anchors, axis, and reference angle using the world anchor and world
+  /// axis.
   void initialize(Body b1, Body b2, Vector2 anchor, Vector2 axis) {
     bodyA = b1;
     bodyB = b2;

--- a/lib/src/dynamics/joints/pulley_joint.dart
+++ b/lib/src/dynamics/joints/pulley_joint.dart
@@ -36,14 +36,14 @@ part of box2d;
 class PulleyJoint extends Joint {
   static const double MIN_PULLEY_LENGTH = 2.0;
 
-  final Vector2 _groundAnchorA = new Vector2.zero();
-  final Vector2 _groundAnchorB = new Vector2.zero();
+  final Vector2 _groundAnchorA = Vector2.zero();
+  final Vector2 _groundAnchorB = Vector2.zero();
   double _lengthA = 0.0;
   double _lengthB = 0.0;
 
   // Solver shared
-  final Vector2 _localAnchorA = new Vector2.zero();
-  final Vector2 _localAnchorB = new Vector2.zero();
+  final Vector2 _localAnchorA = Vector2.zero();
+  final Vector2 _localAnchorB = Vector2.zero();
   double _constant = 0.0;
   double _ratio = 0.0;
   double _impulse = 0.0;
@@ -51,12 +51,12 @@ class PulleyJoint extends Joint {
   // Solver temp
   int _indexA = 0;
   int _indexB = 0;
-  final Vector2 _uA = new Vector2.zero();
-  final Vector2 _uB = new Vector2.zero();
-  final Vector2 _rA = new Vector2.zero();
-  final Vector2 _rB = new Vector2.zero();
-  final Vector2 _localCenterA = new Vector2.zero();
-  final Vector2 _localCenterB = new Vector2.zero();
+  final Vector2 _uA = Vector2.zero();
+  final Vector2 _uB = Vector2.zero();
+  final Vector2 _rA = Vector2.zero();
+  final Vector2 _rB = Vector2.zero();
+  final Vector2 _localCenterA = Vector2.zero();
+  final Vector2 _localCenterB = Vector2.zero();
   double _invMassA = 0.0;
   double _invMassB = 0.0;
   double _invIA = 0.0;

--- a/lib/src/dynamics/joints/pulley_joint.dart
+++ b/lib/src/dynamics/joints/pulley_joint.dart
@@ -1,38 +1,34 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * The pulley joint is connected to two bodies and two fixed ground points. The pulley supports a
- * ratio such that: length1 + ratio * length2 <= constant Yes, the force transmitted is scaled by
- * the ratio. Warning: the pulley joint can get a bit squirrelly by itself. They often work better
- * when combined with prismatic joints. You should also cover the the anchor points with static
- * shapes to prevent one side from going to zero length.
- *
- * @author Daniel Murphy
- */
+/// The pulley joint is connected to two bodies and two fixed ground points. The pulley supports a
+/// ratio such that: length1 + ratio * length2 <= constant Yes, the force transmitted is scaled by
+/// the ratio. Warning: the pulley joint can get a bit squirrelly by itself. They often work better
+/// when combined with prismatic joints. You should also cover the the anchor points with static
+/// shapes to prevent one side from going to zero length.
 class PulleyJoint extends Joint {
   static const double MIN_PULLEY_LENGTH = 2.0;
 

--- a/lib/src/dynamics/joints/pulley_joint_def.dart
+++ b/lib/src/dynamics/joints/pulley_joint_def.dart
@@ -24,55 +24,35 @@
 
 part of box2d;
 
-/**
- * Pulley joint definition. This requires two ground anchors, two dynamic body anchor points, and a
- * pulley ratio.
- * 
- * @author Daniel Murphy
- */
+/// Pulley joint definition. This requires two ground anchors, two dynamic body anchor points, and a
+/// pulley ratio.
 class PulleyJointDef extends JointDef {
-  /**
-   * The first ground anchor in world coordinates. This point never moves.
-   */
+  /// The first ground anchor in world coordinates. This point never moves.
   Vector2 groundAnchorA = new Vector2(-1.0, 1.0);
 
-  /**
-   * The second ground anchor in world coordinates. This point never moves.
-   */
+  /// The second ground anchor in world coordinates. This point never moves.
   Vector2 groundAnchorB = new Vector2(1.0, 1.0);
 
-  /**
-   * The local anchor point relative to bodyA's origin.
-   */
+  /// The local anchor point relative to bodyA's origin.
   Vector2 localAnchorA = new Vector2(-1.0, 0.0);
 
-  /**
-   * The local anchor point relative to bodyB's origin.
-   */
+  /// The local anchor point relative to bodyB's origin.
   Vector2 localAnchorB = new Vector2(1.0, 0.0);
 
-  /**
-   * The a reference length for the segment attached to bodyA.
-   */
+  /// The a reference length for the segment attached to bodyA.
   double lengthA = 0.0;
 
-  /**
-   * The a reference length for the segment attached to bodyB.
-   */
+  /// The a reference length for the segment attached to bodyB.
   double lengthB = 0.0;
 
-  /**
-   * The pulley ratio, used to simulate a block-and-tackle.
-   */
+  /// The pulley ratio, used to simulate a block-and-tackle.
   double ratio = 1.0;
 
   PulleyJointDef() : super(JointType.PULLEY) {
     collideConnected = true;
   }
 
-  /**
-   * Initialize the bodies, anchors, lengths, max lengths, and ratio using the world anchors.
-   */
+  /// Initialize the bodies, anchors, lengths, max lengths, and ratio using the world anchors.
   void initialize(Body b1, Body b2, Vector2 ga1, Vector2 ga2, Vector2 anchor1,
       Vector2 anchor2, double r) {
     bodyA = b1;

--- a/lib/src/dynamics/joints/revolute_joint.dart
+++ b/lib/src/dynamics/joints/revolute_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 //Point-to-point constraint
@@ -36,15 +36,11 @@ part of box2d;
 //J = [0 0 -1 0 0 1]
 //K = invI1 + invI2
 
-/**
- * A revolute joint constrains two bodies to share a common point while they are free to rotate
- * about the point. The relative rotation about the shared point is the joint angle. You can limit
- * the relative rotation with a joint limit that specifies a lower and upper angle. You can use a
- * motor to drive the relative rotation about the shared point. A maximum motor torque is provided
- * so that infinite forces are not generated.
- *
- * @author Daniel Murphy
- */
+/// A revolute joint constrains two bodies to share a common point while they are free to rotate
+/// about the point. The relative rotation about the shared point is the joint angle. You can limit
+/// the relative rotation with a joint limit that specifies a lower and upper angle. You can use a
+/// motor to drive the relative rotation about the shared point. A maximum motor torque is provided
+/// so that infinite forces are not generated.
 class RevoluteJoint extends Joint {
   // Solver shared
   final Vector2 _localAnchorA = new Vector2.zero();

--- a/lib/src/dynamics/joints/revolute_joint_def.dart
+++ b/lib/src/dynamics/joints/revolute_joint_def.dart
@@ -24,72 +24,50 @@
 
 part of box2d;
 
-/**
- * Revolute joint definition. This requires defining an anchor point where the bodies are joined.
- * The definition uses local anchor points so that the initial configuration can violate the
- * constraint slightly. You also need to specify the initial relative angle for joint limits. This
- * helps when saving and loading a game. The local anchor points are measured from the body's origin
- * rather than the center of mass because:<br/>
- * <ul>
- * <li>you might not know where the center of mass will be.</li>
- * <li>if you add/remove shapes from a body and recompute the mass, the joints will be broken.</li>
- * </ul>
- */
+/// Revolute joint definition. This requires defining an anchor point where the bodies are joined.
+/// The definition uses local anchor points so that the initial configuration can violate the
+/// constraint slightly. You also need to specify the initial relative angle for joint limits. This
+/// helps when saving and loading a game. The local anchor points are measured from the body's origin
+/// rather than the center of mass because:<br/>
+/// <ul>
+/// <li>you might not know where the center of mass will be.</li>
+/// <li>if you add/remove shapes from a body and recompute the mass, the joints will be broken.</li>
+/// </ul>
 class RevoluteJointDef extends JointDef {
-  /**
-   * The local anchor point relative to body1's origin.
-   */
+  /// The local anchor point relative to body1's origin.
   Vector2 localAnchorA = new Vector2.zero();
 
-  /**
-   * The local anchor point relative to body2's origin.
-   */
+  /// The local anchor point relative to body2's origin.
   Vector2 localAnchorB = new Vector2.zero();
 
-  /**
-   * The body2 angle minus body1 angle in the reference state (radians).
-   */
+  /// The body2 angle minus body1 angle in the reference state (radians).
   double referenceAngle = 0.0;
 
-  /**
-   * A flag to enable joint limits.
-   */
+  /// A flag to enable joint limits.
   bool enableLimit = false;
 
-  /**
-   * The lower angle for the joint limit (radians).
-   */
+  /// The lower angle for the joint limit (radians).
   double lowerAngle = 0.0;
 
-  /**
-   * The upper angle for the joint limit (radians).
-   */
+  /// The upper angle for the joint limit (radians).
   double upperAngle = 0.0;
 
-  /**
-   * A flag to enable the joint motor.
-   */
+  /// A flag to enable the joint motor.
   bool enableMotor = false;
 
-  /**
-   * The desired motor speed. Usually in radians per second.
-   */
+  /// The desired motor speed. Usually in radians per second.
   double motorSpeed = 0.0;
 
-  /**
-   * The maximum motor torque used to achieve the desired motor speed. Usually in N-m.
-   */
+  /// The maximum motor torque used to achieve the desired motor speed. Usually in N-m.
   double maxMotorTorque = 0.0;
 
   RevoluteJointDef() : super(JointType.REVOLUTE);
 
-  /**
-   * Initialize the bodies, anchors, and reference angle using the world anchor.
-   * 
-   * @param b1
-   * @param b2
-   * @param anchor
-   */
+  /// Initialize the bodies, anchors, and reference angle using the world anchor.
+  ///
+  /// @param b1
+  /// @param b2
+  /// @param anchor
   void initialize(final Body b1, final Body b2, final Vector2 anchor) {
     bodyA = b1;
     bodyB = b2;

--- a/lib/src/dynamics/joints/rope_joint.dart
+++ b/lib/src/dynamics/joints/rope_joint.dart
@@ -35,8 +35,8 @@ part of box2d;
  */
 class RopeJoint extends Joint {
   // Solver shared
-  final Vector2 _localAnchorA = new Vector2.zero();
-  final Vector2 _localAnchorB = new Vector2.zero();
+  final Vector2 _localAnchorA = Vector2.zero();
+  final Vector2 _localAnchorB = Vector2.zero();
   double _maxLength = 0.0;
   double _length = 0.0;
   double _impulse = 0.0;
@@ -44,11 +44,11 @@ class RopeJoint extends Joint {
   // Solver temp
   int _indexA = 0;
   int _indexB = 0;
-  final Vector2 _u = new Vector2.zero();
-  final Vector2 _rA = new Vector2.zero();
-  final Vector2 _rB = new Vector2.zero();
-  final Vector2 _localCenterA = new Vector2.zero();
-  final Vector2 _localCenterB = new Vector2.zero();
+  final Vector2 _u = Vector2.zero();
+  final Vector2 _rA = Vector2.zero();
+  final Vector2 _rB = Vector2.zero();
+  final Vector2 _localCenterA = Vector2.zero();
+  final Vector2 _localCenterB = Vector2.zero();
   double _invMassA = 0.0;
   double _invMassB = 0.0;
   double _invIA = 0.0;

--- a/lib/src/dynamics/joints/rope_joint.dart
+++ b/lib/src/dynamics/joints/rope_joint.dart
@@ -1,38 +1,34 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * A rope joint enforces a maximum distance between two points on two bodies. It has no other
- * effect. Warning: if you attempt to change the maximum length during the simulation you will get
- * some non-physical behavior. A model that would allow you to dynamically modify the length would
- * have some sponginess, so I chose not to implement it that way. See DistanceJoint if you want to
- * dynamically control length.
- *
- * @author Daniel Murphy
- */
+/// A rope joint enforces a maximum distance between two points on two bodies. It has no other
+/// effect. Warning: if you attempt to change the maximum length during the simulation you will get
+/// some non-physical behavior. A model that would allow you to dynamically modify the length would
+/// have some sponginess, so I chose not to implement it that way. See DistanceJoint if you want to
+/// dynamically control length.
 class RopeJoint extends Joint {
   // Solver shared
   final Vector2 _localAnchorA = Vector2.zero();

--- a/lib/src/dynamics/joints/rope_joint_def.dart
+++ b/lib/src/dynamics/joints/rope_joint_def.dart
@@ -24,27 +24,17 @@
 
 part of box2d;
 
-/**
- * Rope joint definition. This requires two body anchor points and a maximum lengths. Note: by
- * default the connected objects will not collide. see collideConnected in b2JointDef.
- * 
- * @author Daniel Murphy
- */
+/// Rope joint definition. This requires two body anchor points and a maximum lengths. Note: by
+/// default the connected objects will not collide. see collideConnected in b2JointDef.
 class RopeJointDef extends JointDef {
-  /**
-   * The local anchor point relative to bodyA's origin.
-   */
+  /// The local anchor point relative to bodyA's origin.
   final Vector2 localAnchorA = new Vector2.zero();
 
-  /**
-   * The local anchor point relative to bodyB's origin.
-   */
+  /// The local anchor point relative to bodyB's origin.
   final Vector2 localAnchorB = new Vector2.zero();
 
-  /**
-   * The maximum length of the rope. Warning: this must be larger than b2_linearSlop or the joint
-   * will have no effect.
-   */
+  /// The maximum length of the rope. Warning: this must be larger than b2_linearSlop or the joint
+  /// will have no effect.
   double maxLength = 0.0;
 
   RopeJointDef() : super(JointType.ROPE) {

--- a/lib/src/dynamics/joints/weld_joint.dart
+++ b/lib/src/dynamics/joints/weld_joint.dart
@@ -180,7 +180,7 @@ class WeldJoint extends Joint {
       double C = aB - aA - _referenceAngle;
 
       // Frequency
-      double omega = 2.0 * Math.PI * _frequencyHz;
+      double omega = 2.0 * Math.pi * _frequencyHz;
 
       // Damping coefficient
       double d = 2.0 * m * _dampingRatio * omega;

--- a/lib/src/dynamics/joints/weld_joint.dart
+++ b/lib/src/dynamics/joints/weld_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -38,12 +38,8 @@ part of box2d;
 //J = [0 0 -1 0 0 1]
 //K = invI1 + invI2
 
-/**
- * A weld joint essentially glues two bodies together. A weld joint may distort somewhat because the
- * island constraint solver is approximate.
- *
- * @author Daniel Murphy
- */
+/// A weld joint essentially glues two bodies together. A weld joint may distort somewhat because the
+/// island constraint solver is approximate.
 class WeldJoint extends Joint {
   double _frequencyHz = 0.0;
   double _dampingRatio = 0.0;

--- a/lib/src/dynamics/joints/weld_joint_def.dart
+++ b/lib/src/dynamics/joints/weld_joint_def.dart
@@ -25,40 +25,28 @@
 part of box2d;
 
 class WeldJointDef extends JointDef {
-  /**
-   * The local anchor point relative to body1's origin.
-   */
+  /// The local anchor point relative to body1's origin.
   final Vector2 localAnchorA = new Vector2.zero();
 
-  /**
-   * The local anchor point relative to body2's origin.
-   */
+  /// The local anchor point relative to body2's origin.
   final Vector2 localAnchorB = new Vector2.zero();
 
-  /**
-   * The body2 angle minus body1 angle in the reference state (radians).
-   */
+  /// The body2 angle minus body1 angle in the reference state (radians).
   double referenceAngle = 0.0;
 
-  /**
-   * The mass-spring-damper frequency in Hertz. Rotation only. Disable softness with a value of 0.
-   */
+  /// The mass-spring-damper frequency in Hertz. Rotation only. Disable softness with a value of 0.
   double frequencyHz = 0.0;
 
-  /**
-   * The damping ratio. 0 = no damping, 1 = critical damping.
-   */
+  /// The damping ratio. 0 = no damping, 1 = critical damping.
   double dampingRatio = 0.0;
 
   WeldJointDef() : super(JointType.WELD);
 
-  /**
-   * Initialize the bodies, anchors, and reference angle using a world anchor point.
-   * 
-   * @param bA
-   * @param bB
-   * @param anchor
-   */
+  /// Initialize the bodies, anchors, and reference angle using a world anchor point.
+  ///
+  /// @param bA
+  /// @param bB
+  /// @param anchor
   void initialize(Body bA, Body bB, Vector2 anchor) {
     bodyA = bA;
     bodyB = bB;

--- a/lib/src/dynamics/joints/wheel_joint.dart
+++ b/lib/src/dynamics/joints/wheel_joint.dart
@@ -290,7 +290,7 @@ class WheelJoint extends Joint {
         double C = d.dot(_ax);
 
         // Frequency
-        double omega = 2.0 * Math.PI * _frequencyHz;
+        double omega = 2.0 * Math.pi * _frequencyHz;
 
         // Damping coefficient
         double dd = 2.0 * _springMass * _dampingRatio * omega;

--- a/lib/src/dynamics/joints/wheel_joint.dart
+++ b/lib/src/dynamics/joints/wheel_joint.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -40,14 +40,10 @@ part of box2d;
 //Cdot = wB - wA
 //J = [0 0 -1 0 0 1]
 
-/**
- * A wheel joint. This joint provides two degrees of freedom: translation along an axis fixed in
- * bodyA and rotation in the plane. You can use a joint limit to restrict the range of motion and a
- * joint motor to drive the rotation or to model rotational friction. This joint is designed for
- * vehicle suspensions.
- *
- * @author Daniel Murphy
- */
+/// A wheel joint. This joint provides two degrees of freedom: translation along an axis fixed in
+/// bodyA and rotation in the plane. You can use a joint limit to restrict the range of motion and a
+/// joint motor to drive the rotation or to model rotational friction. This joint is designed for
+/// vehicle suspensions.
 class WheelJoint extends Joint {
   // TODO(srdjan): make fields private.
   double _frequencyHz = 0.0;
@@ -156,7 +152,7 @@ class WheelJoint extends Joint {
     return translation;
   }
 
-  /** For serialization */
+  /// For serialization
   Vector2 getLocalAxisA() {
     return _localXAxisA;
   }

--- a/lib/src/dynamics/joints/wheel_joint_def.dart
+++ b/lib/src/dynamics/joints/wheel_joint_def.dart
@@ -37,17 +37,17 @@ class WheelJointDef extends JointDef {
   /**
    * The local anchor point relative to body1's origin.
    */
-  final Vector2 localAnchorA = new Vector2.zero();
+  final Vector2 localAnchorA = Vector2.zero();
 
   /**
    * The local anchor point relative to body2's origin.
    */
-  final Vector2 localAnchorB = new Vector2.zero();
+  final Vector2 localAnchorB = Vector2.zero();
 
   /**
    * The local translation axis in body1.
    */
-  final Vector2 localAxisA = new Vector2.zero();
+  final Vector2 localAxisA = Vector2.zero();
 
   /**
    * Enable/disable the joint motor.

--- a/lib/src/dynamics/joints/wheel_joint_def.dart
+++ b/lib/src/dynamics/joints/wheel_joint_def.dart
@@ -24,54 +24,34 @@
 
 part of box2d;
 
-/**
- * Wheel joint definition. This requires defining a line of motion using an axis and an anchor
- * point. The definition uses local anchor points and a local axis so that the initial configuration
- * can violate the constraint slightly. The joint translation is zero when the local anchor points
- * coincide in world space. Using local anchors and a local axis helps when saving and loading a
- * game.
- * 
- * @author Daniel Murphy
- */
+/// Wheel joint definition. This requires defining a line of motion using an axis and an anchor
+/// point. The definition uses local anchor points and a local axis so that the initial configuration
+/// can violate the constraint slightly. The joint translation is zero when the local anchor points
+/// coincide in world space. Using local anchors and a local axis helps when saving and loading a
+/// game.
 class WheelJointDef extends JointDef {
-  /**
-   * The local anchor point relative to body1's origin.
-   */
+  /// The local anchor point relative to body1's origin.
   final Vector2 localAnchorA = Vector2.zero();
 
-  /**
-   * The local anchor point relative to body2's origin.
-   */
+  /// The local anchor point relative to body2's origin.
   final Vector2 localAnchorB = Vector2.zero();
 
-  /**
-   * The local translation axis in body1.
-   */
+  /// The local translation axis in body1.
   final Vector2 localAxisA = Vector2.zero();
 
-  /**
-   * Enable/disable the joint motor.
-   */
+  /// Enable/disable the joint motor.
   bool enableMotor = false;
 
-  /**
-   * The maximum motor torque, usually in N-m.
-   */
+  /// The maximum motor torque, usually in N-m.
   double maxMotorTorque = 0.0;
 
-  /**
-   * The desired motor speed in radians per second.
-   */
+  /// The desired motor speed in radians per second.
   double motorSpeed = 0.0;
 
-  /**
-   * Suspension frequency, zero indicates no suspension
-   */
+  /// Suspension frequency, zero indicates no suspension
   double frequencyHz = 0.0;
 
-  /**
-   * Suspension damping ratio, one indicates critical damping
-   */
+  /// Suspension damping ratio, one indicates critical damping
   double dampingRatio = 0.0;
 
   WheelJointDef() : super(JointType.WHEEL) {

--- a/lib/src/dynamics/profile.dart
+++ b/lib/src/dynamics/profile.dart
@@ -32,8 +32,8 @@ class ProfileEntry {
 
   double longAvg = 0.0;
   double shortAvg = 0.0;
-  double min = double.MAX_FINITE;
-  double max = -double.MAX_FINITE;
+  double min = double.maxFinite;
+  double max = -double.maxFinite;
   double _accum = 0.0;
 
   void record(double value) {

--- a/lib/src/dynamics/profile.dart
+++ b/lib/src/dynamics/profile.dart
@@ -61,16 +61,16 @@ class ProfileEntry {
 }
 
 class Profile {
-  final ProfileEntry step = new ProfileEntry();
-  final ProfileEntry stepInit = new ProfileEntry();
-  final ProfileEntry collide = new ProfileEntry();
-  final ProfileEntry solveParticleSystem = new ProfileEntry();
-  final ProfileEntry solve = new ProfileEntry();
-  final ProfileEntry solveInit = new ProfileEntry();
-  final ProfileEntry solveVelocity = new ProfileEntry();
-  final ProfileEntry solvePosition = new ProfileEntry();
-  final ProfileEntry broadphase = new ProfileEntry();
-  final ProfileEntry solveTOI = new ProfileEntry();
+  final ProfileEntry step = ProfileEntry();
+  final ProfileEntry stepInit = ProfileEntry();
+  final ProfileEntry collide = ProfileEntry();
+  final ProfileEntry solveParticleSystem = ProfileEntry();
+  final ProfileEntry solve = ProfileEntry();
+  final ProfileEntry solveInit = ProfileEntry();
+  final ProfileEntry solveVelocity = ProfileEntry();
+  final ProfileEntry solvePosition = ProfileEntry();
+  final ProfileEntry broadphase = ProfileEntry();
+  final ProfileEntry solveTOI = ProfileEntry();
 
   void toDebugStrings(List<String> strings) {
     strings.add("Profile:");

--- a/lib/src/dynamics/time_step.dart
+++ b/lib/src/dynamics/time_step.dart
@@ -24,17 +24,15 @@
 
 part of box2d;
 
-/**
- * This is an internal structure.
- */
+/// This is an internal structure.
 class TimeStep {
-  /** time step */
+  /// time step
   double dt = 0.0;
 
-  /** inverse time step (0 if dt == 0). */
+  /// inverse time step (0 if dt == 0).
   double inv_dt = 0.0;
 
-  /** dt * inv_dt0 */
+  /// dt * inv_dt0
   double dtRatio = 0.0;
 
   int velocityIterations = 0;

--- a/lib/src/dynamics/world.dart
+++ b/lib/src/dynamics/world.dart
@@ -1,33 +1,31 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
-/**
- * The world class manages all physics entities, dynamic simulation, and asynchronous queries. The
- * world also contains efficient memory management facilities.
- */
+/// The world class manages all physics entities, dynamic simulation, and asynchronous queries. The
+/// world also contains efficient memory management facilities.
 class World {
   static const int WORLD_POOL_SIZE = 100;
   static const int WORLD_POOL_CONTAINER_SIZE = 10;
@@ -56,9 +54,7 @@ class World {
 
   final IWorldPool _pool;
 
-  /**
-   * This is used to compute the time step ratio to support a variable time step.
-   */
+  /// This is used to compute the time step ratio to support a variable time step.
   double _inv_dt0 = 0.0;
 
   // these are for debugging the solver
@@ -83,22 +79,18 @@ class World {
   List<List<ContactRegister>> contactStacks =
       _create2D(ShapeType.values.length, ShapeType.values.length);
 
-  /**
-   * Construct a world object.
-   *
-   * @param gravity the world gravity vector.
-   */
+  /// Construct a world object.
+  ///
+  /// @param gravity the world gravity vector.
   factory World.withGravity(Vector2 gravity) {
     var w = new World.withPool(gravity,
         new DefaultWorldPool(WORLD_POOL_SIZE, WORLD_POOL_CONTAINER_SIZE));
     return w;
   }
 
-  /**
-   * Construct a world object.
-   *
-   * @param gravity the world gravity vector.
-   */
+  /// Construct a world object.
+  ///
+  /// @param gravity the world gravity vector.
   factory World.withPool(Vector2 gravity, IWorldPool pool) {
     var w = new World.withPoolAndStrategy(gravity, pool, new DynamicTree());
     return w;
@@ -251,51 +243,41 @@ class World {
     return _pool;
   }
 
-  /**
-   * Register a destruction listener. The listener is owned by you and must remain in scope.
-   *
-   * @param listener
-   */
+  /// Register a destruction listener. The listener is owned by you and must remain in scope.
+  ///
+  /// @param listener
   void setDestructionListener(DestructionListener listener) {
     _destructionListener = listener;
   }
 
-  /**
-   * Register a contact filter to provide specific control over collision. Otherwise the default
-   * filter is used (_defaultFilter). The listener is owned by you and must remain in scope.
-   *
-   * @param filter
-   */
+  /// Register a contact filter to provide specific control over collision. Otherwise the default
+  /// filter is used (_defaultFilter). The listener is owned by you and must remain in scope.
+  ///
+  /// @param filter
   void setContactFilter(ContactFilter filter) {
     _contactManager.contactFilter = filter;
   }
 
-  /**
-   * Register a contact event listener. The listener is owned by you and must remain in scope.
-   *
-   * @param listener
-   */
+  /// Register a contact event listener. The listener is owned by you and must remain in scope.
+  ///
+  /// @param listener
   void setContactListener(ContactListener listener) {
     _contactManager.contactListener = listener;
   }
 
-  /**
-   * Register a routine for debug drawing. The debug draw functions are called inside with
-   * World.DrawDebugData method. The debug draw object is owned by you and must remain in scope.
-   *
-   * @param debugDraw
-   */
+  /// Register a routine for debug drawing. The debug draw functions are called inside with
+  /// World.DrawDebugData method. The debug draw object is owned by you and must remain in scope.
+  ///
+  /// @param debugDraw
   void setDebugDraw(DebugDraw debugDraw) {
     debugDraw = debugDraw;
   }
 
-  /**
-   * create a rigid body given a definition. No reference to the definition is retained.
-   *
-   * @warning This function is locked during callbacks.
-   * @param def
-   * @return
-   */
+  /// create a rigid body given a definition. No reference to the definition is retained.
+  ///
+  /// @warning This function is locked during callbacks.
+  /// @param def
+  /// @return
   Body createBody(BodyDef def) {
     assert(isLocked() == false);
     if (isLocked()) {
@@ -316,14 +298,11 @@ class World {
     return b;
   }
 
-  /**
-   * destroy a rigid body given a definition. No reference to the definition is retained. This
-   * function is locked during callbacks.
-   *
-   * @warning This automatically deletes all associated shapes and joints.
-   * @warning This function is locked during callbacks.
-   * @param body
-   */
+  /// Destroys a rigid body given a definition. No reference to the definition is retained. This
+  /// function is locked during callbacks.
+  ///
+  /// @warning This automatically deletes all associated shapes and joints.
+  /// @warning This function is locked during callbacks.
   void destroyBody(Body body) {
     assert(_bodyCount > 0);
     assert(isLocked() == false);
@@ -390,14 +369,10 @@ class World {
     // TODO djm recycle body
   }
 
-  /**
-   * create a joint to constrain bodies together. No reference to the definition is retained. This
-   * may cause the connected bodies to cease colliding.
-   *
-   * @warning This function is locked during callbacks.
-   * @param def
-   * @return
-   */
+  /// create a joint to constrain bodies together. No reference to the definition is retained.
+  /// This may cause the connected bodies to cease colliding.
+  ///
+  /// @warning This function is locked during callbacks.
   Joint createJoint(JointDef def) {
     assert(isLocked() == false);
     if (isLocked()) {
@@ -456,12 +431,10 @@ class World {
     return j;
   }
 
-  /**
-   * destroy a joint. This may cause the connected bodies to begin colliding.
-   *
-   * @warning This function is locked during callbacks.
-   * @param joint
-   */
+  /// destroy a joint. This may cause the connected bodies to begin colliding.
+  ///
+  /// @warning This function is locked during callbacks.
+  /// @param joint
   void destroyJoint(Joint j) {
     assert(isLocked() == false);
     if (isLocked()) {
@@ -549,13 +522,11 @@ class World {
   final Timer stepTimer = new Timer();
   final Timer tempTimer = new Timer();
 
-  /**
-   * Take a time step. This performs collision detection, integration, and constraint solution.
-   *
-   * @param timeStep the amount of time to simulate, this should not vary.
-   * @param velocityIterations for the velocity constraint solver.
-   * @param positionIterations for the position constraint solver.
-   */
+  /// Take a time step. This performs collision detection, integration, and constraint solution.
+  ///
+  /// @param timeStep the amount of time to simulate, this should not vary.
+  /// @param velocityIterations for the velocity constraint solver.
+  /// @param positionIterations for the position constraint solver.
   void stepDt(double dt, int velocityIterations, int positionIterations) {
     stepTimer.reset();
     tempTimer.reset();
@@ -619,13 +590,11 @@ class World {
     _profile.step.record(stepTimer.getMilliseconds());
   }
 
-  /**
-   * Call this after you are done with time steps to clear the forces. You normally call this after
-   * each call to Step, unless you are performing sub-steps. By default, forces will be
-   * automatically cleared, so you don't need to call this function.
-   *
-   * @see setAutoClearForces
-   */
+  /// Call this after you are done with time steps to clear the forces. You normally call this after
+  /// each call to Step, unless you are performing sub-steps. By default, forces will be
+  /// automatically cleared, so you don't need to call this function.
+  ///
+  /// @see setAutoClearForces
   void clearForces() {
     for (Body body = bodyList; body != null; body = body.getNext()) {
       body._force.setZero();
@@ -639,9 +608,7 @@ class World {
   final Vector2 cB = new Vector2.zero();
   final Vec2Array avs = new Vec2Array();
 
-  /**
-   * Call this to draw shapes and other debug draw data.
-   */
+  /// Call this to draw shapes and other debug draw data.
   void drawDebugData() {
     if (debugDraw == null) {
       return;
@@ -737,25 +704,21 @@ class World {
 
   final WorldQueryWrapper wqwrapper = new WorldQueryWrapper();
 
-  /**
-   * Query the world for all fixtures that potentially overlap the provided AABB.
-   *
-   * @param callback a user implemented callback class.
-   * @param aabb the query box.
-   */
+  /// Query the world for all fixtures that potentially overlap the provided AABB.
+  ///
+  /// @param callback a user implemented callback class.
+  /// @param aabb the query box.
   void queryAABB(QueryCallback callback, AABB aabb) {
     wqwrapper.broadPhase = _contactManager.broadPhase;
     wqwrapper.callback = callback;
     _contactManager.broadPhase.query(wqwrapper, aabb);
   }
 
-  /**
-   * Query the world for all fixtures and particles that potentially overlap the provided AABB.
-   *
-   * @param callback a user implemented callback class.
-   * @param particleCallback callback for particles.
-   * @param aabb the query box.
-   */
+  /// Query the world for all fixtures and particles that potentially overlap the provided AABB.
+  ///
+  /// @param callback a user implemented callback class.
+  /// @param particleCallback callback for particles.
+  /// @param aabb the query box.
   void queryAABBTwoCallbacks(QueryCallback callback,
       ParticleQueryCallback particleCallback, AABB aabb) {
     wqwrapper.broadPhase = _contactManager.broadPhase;
@@ -764,12 +727,10 @@ class World {
     _particleSystem.queryAABB(particleCallback, aabb);
   }
 
-  /**
-   * Query the world for all particles that potentially overlap the provided AABB.
-   *
-   * @param particleCallback callback for particles.
-   * @param aabb the query box.
-   */
+  /// Query the world for all particles that potentially overlap the provided AABB.
+  ///
+  /// @param particleCallback callback for particles.
+  /// @param aabb the query box.
   void queryAABBParticle(ParticleQueryCallback particleCallback, AABB aabb) {
     _particleSystem.queryAABB(particleCallback, aabb);
   }
@@ -777,15 +738,13 @@ class World {
   final WorldRayCastWrapper wrcwrapper = new WorldRayCastWrapper();
   final RayCastInput input = new RayCastInput();
 
-  /**
-   * Ray-cast the world for all fixtures in the path of the ray. Your callback controls whether you
-   * get the closest point, any point, or n-points. The ray-cast ignores shapes that contain the
-   * starting point.
-   *
-   * @param callback a user implemented callback class.
-   * @param point1 the ray starting point
-   * @param point2 the ray ending point
-   */
+  /// Ray-cast the world for all fixtures in the path of the ray. Your callback controls whether you
+  /// get the closest point, any point, or n-points. The ray-cast ignores shapes that contain the
+  /// starting point.
+  ///
+  /// @param callback a user implemented callback class.
+  /// @param point1 the ray starting point
+  /// @param point2 the ray ending point
   void raycast(RayCastCallback callback, Vector2 point1, Vector2 point2) {
     wrcwrapper.broadPhase = _contactManager.broadPhase;
     wrcwrapper.callback = callback;
@@ -795,16 +754,14 @@ class World {
     _contactManager.broadPhase.raycast(wrcwrapper, input);
   }
 
-  /**
-   * Ray-cast the world for all fixtures and particles in the path of the ray. Your callback
-   * controls whether you get the closest point, any point, or n-points. The ray-cast ignores shapes
-   * that contain the starting point.
-   *
-   * @param callback a user implemented callback class.
-   * @param particleCallback the particle callback class.
-   * @param point1 the ray starting point
-   * @param point2 the ray ending point
-   */
+  /// Ray-cast the world for all fixtures and particles in the path of the ray. Your callback
+  /// controls whether you get the closest point, any point, or n-points. The ray-cast ignores shapes
+  /// that contain the starting point.
+  ///
+  /// @param callback a user implemented callback class.
+  /// @param particleCallback the particle callback class.
+  /// @param point1 the ray starting point
+  /// @param point2 the ray ending point
   void raycastTwoCallBacks(
       RayCastCallback callback,
       ParticleRaycastCallback particleCallback,
@@ -819,108 +776,68 @@ class World {
     _particleSystem.raycast(particleCallback, point1, point2);
   }
 
-  /**
-   * Ray-cast the world for all particles in the path of the ray. Your callback controls whether you
-   * get the closest point, any point, or n-points.
-   *
-   * @param particleCallback the particle callback class.
-   * @param point1 the ray starting point
-   * @param point2 the ray ending point
-   */
+  /// Ray-cast the world for all particles in the path of the ray. Your callback controls whether you
+  /// get the closest point, any point, or n-points.
+  ///
+  /// @param particleCallback the particle callback class.
+  /// @param point1 the ray starting point
+  /// @param point2 the ray ending point
   void raycastParticle(ParticleRaycastCallback particleCallback, Vector2 point1,
       Vector2 point2) {
     _particleSystem.raycast(particleCallback, point1, point2);
   }
 
-  /**
-   * Get the world contact list. With the returned contact, use Contact.getNext to get the next
-   * contact in the world list. A null contact indicates the end of the list.
-   *
-   * @return the head of the world contact list.
-   * @warning contacts are created and destroyed in the middle of a time step. Use ContactListener
-   *          to avoid missing contacts.
-   */
+  /// Get the world contact list. With the returned contact, use Contact.getNext to get the next
+  /// contact in the world list. A null contact indicates the end of the list.
+  ///
+  /// @return the head of the world contact list.
+  /// @warning contacts are created and destroyed in the middle of a time step. Use ContactListener
+  ///          to avoid missing contacts.
   Contact getContactList() {
     return _contactManager.contactList;
   }
 
-  /**
-   * Get the number of broad-phase proxies.
-   *
-   * @return
-   */
+  /// Get the number of broad-phase proxies.
   int getProxyCount() {
     return _contactManager.broadPhase.getProxyCount();
   }
 
-  /**
-   * Get the number of contacts (each may have 0 or more contact points).
-   *
-   * @return
-   */
+  /// Get the number of contacts (each may have 0 or more contact points).
   int getContactCount() {
     return _contactManager.contactCount;
   }
 
-  /**
-   * Gets the height of the dynamic tree
-   *
-   * @return
-   */
+  /// Gets the height of the dynamic tree
   int getTreeHeight() {
     return _contactManager.broadPhase.getTreeHeight();
   }
 
-  /**
-   * Gets the balance of the dynamic tree
-   *
-   * @return
-   */
+  /// Gets the balance of the dynamic tree
   int getTreeBalance() {
     return _contactManager.broadPhase.getTreeBalance();
   }
 
-  /**
-   * Gets the quality of the dynamic tree
-   *
-   * @return
-   */
+  /// Gets the quality of the dynamic tree
   double getTreeQuality() {
     return _contactManager.broadPhase.getTreeQuality();
   }
 
-  /**
-   * Change the global gravity vector.
-   *
-   * @param gravity
-   */
+  /// Change the global gravity vector.
   void setGravity(Vector2 gravity) {
     _gravity.setFrom(gravity);
   }
 
-  /**
-   * Get the global gravity vector.
-   *
-   * @return
-   */
+  /// Get the global gravity vector.
   Vector2 getGravity() {
     return _gravity;
   }
 
-  /**
-   * Is the world locked (in the middle of a time step).
-   *
-   * @return
-   */
+  /// Is the world locked (in the middle of a time step).
   bool isLocked() {
     return (_flags & LOCKED) == LOCKED;
   }
 
-  /**
-   * Set flag to control automatic clearing of forces after each time step.
-   *
-   * @param flag
-   */
+  /// Set flag to control automatic clearing of forces after each time step.
   void setAutoClearForces(bool flag) {
     if (flag) {
       _flags |= CLEAR_FORCES;
@@ -929,11 +846,7 @@ class World {
     }
   }
 
-  /**
-   * Get the flag that controls automatic clearing of forces after each time step.
-   *
-   * @return
-   */
+  /// Get the flag that controls automatic clearing of forces after each time step.
   bool getAutoClearForces() {
     return (_flags & CLEAR_FORCES) == CLEAR_FORCES;
   }
@@ -1560,15 +1473,13 @@ class World {
     }
   }
 
-  /**
-   * Create a particle whose properties have been defined. No reference to the definition is
-   * retained. A simulation step must occur before it's possible to interact with a newly created
-   * particle. For example, DestroyParticleInShape() will not destroy a particle until Step() has
-   * been called.
-   *
-   * @warning This function is locked during callbacks.
-   * @return the index of the particle.
-   */
+  /// Create a particle whose properties have been defined. No reference to the definition is
+  /// retained. A simulation step must occur before it's possible to interact with a newly created
+  /// particle. For example, DestroyParticleInShape() will not destroy a particle until Step() has
+  /// been called.
+  ///
+  /// @warning This function is locked during callbacks.
+  /// @return the index of the particle.
   int createParticle(ParticleDef def) {
     assert(isLocked() == false);
     if (isLocked()) {
@@ -1578,50 +1489,42 @@ class World {
     return p;
   }
 
-  /**
-   * Destroy a particle. The particle is removed after the next step.
-   *
-   * @param index
-   */
+  /// Destroy a particle. The particle is removed after the next step.
+  ///
+  /// @param index
   void destroyParticle(int index) {
     destroyParticleFlag(index, false);
   }
 
-  /**
-   * Destroy a particle. The particle is removed after the next step.
-   *
-   * @param Index of the particle to destroy.
-   * @param Whether to call the destruction listener just before the particle is destroyed.
-   */
+  /// Destroy a particle. The particle is removed after the next step.
+  ///
+  /// @param Index of the particle to destroy.
+  /// @param Whether to call the destruction listener just before the particle is destroyed.
   void destroyParticleFlag(int index, bool callDestructionListener) {
     _particleSystem.destroyParticle(index, callDestructionListener);
   }
 
-  /**
-   * Destroy particles inside a shape without enabling the destruction callback for destroyed
-   * particles. This function is locked during callbacks. For more information see
-   * DestroyParticleInShape(Shape&, Transform&,bool).
-   *
-   * @param Shape which encloses particles that should be destroyed.
-   * @param Transform applied to the shape.
-   * @warning This function is locked during callbacks.
-   * @return Number of particles destroyed.
-   */
+  /// Destroy particles inside a shape without enabling the destruction callback for destroyed
+  /// particles. This function is locked during callbacks. For more information see
+  /// DestroyParticleInShape(Shape&, Transform&,bool).
+  ///
+  /// @param Shape which encloses particles that should be destroyed.
+  /// @param Transform applied to the shape.
+  /// @warning This function is locked during callbacks.
+  /// @return Number of particles destroyed.
   int destroyParticlesInShape(Shape shape, Transform xf) {
     return destroyParticlesInShapeFlag(shape, xf, false);
   }
 
-  /**
-   * Destroy particles inside a shape. This function is locked during callbacks. In addition, this
-   * function immediately destroys particles in the shape in contrast to DestroyParticle() which
-   * defers the destruction until the next simulation step.
-   *
-   * @param Shape which encloses particles that should be destroyed.
-   * @param Transform applied to the shape.
-   * @param Whether to call the world b2DestructionListener for each particle destroyed.
-   * @warning This function is locked during callbacks.
-   * @return Number of particles destroyed.
-   */
+  /// Destroy particles inside a shape. This function is locked during callbacks. In addition, this
+  /// function immediately destroys particles in the shape in contrast to DestroyParticle() which
+  /// defers the destruction until the next simulation step.
+  ///
+  /// @param Shape which encloses particles that should be destroyed.
+  /// @param Transform applied to the shape.
+  /// @param Whether to call the world b2DestructionListener for each particle destroyed.
+  /// @warning This function is locked during callbacks.
+  /// @return Number of particles destroyed.
   int destroyParticlesInShapeFlag(
       Shape shape, Transform xf, bool callDestructionListener) {
     assert(isLocked() == false);
@@ -1632,12 +1535,10 @@ class World {
         shape, xf, callDestructionListener);
   }
 
-  /**
-   * Create a particle group whose properties have been defined. No reference to the definition is
-   * retained.
-   *
-   * @warning This function is locked during callbacks.
-   */
+  /// Create a particle group whose properties have been defined. No reference to the definition is
+  /// retained.
+  ///
+  /// @warning This function is locked during callbacks.
   ParticleGroup createParticleGroup(ParticleGroupDef def) {
     assert(isLocked() == false);
     if (isLocked()) {
@@ -1647,13 +1548,11 @@ class World {
     return g;
   }
 
-  /**
-   * Join two particle groups.
-   *
-   * @param the first group. Expands to encompass the second group.
-   * @param the second group. It is destroyed.
-   * @warning This function is locked during callbacks.
-   */
+  /// Join two particle groups.
+  ///
+  /// @param the first group. Expands to encompass the second group.
+  /// @param the second group. It is destroyed.
+  /// @warning This function is locked during callbacks.
   void joinParticleGroups(ParticleGroup groupA, ParticleGroup groupB) {
     assert(isLocked() == false);
     if (isLocked()) {
@@ -1662,13 +1561,11 @@ class World {
     _particleSystem.joinParticleGroups(groupA, groupB);
   }
 
-  /**
-   * Destroy particles in a group. This function is locked during callbacks.
-   *
-   * @param The particle group to destroy.
-   * @param Whether to call the world b2DestructionListener for each particle is destroyed.
-   * @warning This function is locked during callbacks.
-   */
+  /// Destroy particles in a group. This function is locked during callbacks.
+  ///
+  /// @param The particle group to destroy.
+  /// @param Whether to call the world b2DestructionListener for each particle is destroyed.
+  /// @warning This function is locked during callbacks.
   void destroyParticlesInGroupFlag(
       ParticleGroup group, bool callDestructionListener) {
     assert(isLocked() == false);
@@ -1678,144 +1575,114 @@ class World {
     _particleSystem.destroyParticlesInGroup(group, callDestructionListener);
   }
 
-  /**
-   * Destroy particles in a group without enabling the destruction callback for destroyed particles.
-   * This function is locked during callbacks.
-   *
-   * @param The particle group to destroy.
-   * @warning This function is locked during callbacks.
-   */
+  /// Destroy particles in a group without enabling the destruction callback for destroyed particles.
+  /// This function is locked during callbacks.
+  ///
+  /// @param The particle group to destroy.
+  /// @warning This function is locked during callbacks.
   void destroyParticlesInGroup(ParticleGroup group) {
     destroyParticlesInGroupFlag(group, false);
   }
 
-  /**
-   * Get the world particle group list. With the returned group, use ParticleGroup::GetNext to get
-   * the next group in the world list. A NULL group indicates the end of the list.
-   *
-   * @return the head of the world particle group list.
-   */
+  /// Get the world particle group list. With the returned group, use ParticleGroup::GetNext to get
+  /// the next group in the world list. A NULL group indicates the end of the list.
+  ///
+  /// @return the head of the world particle group list.
   List<ParticleGroup> getParticleGroupList() {
     return _particleSystem.getParticleGroupList();
   }
 
-  /**
-   * Get the number of particle groups.
-   *
-   * @return
-   */
+  /// Get the number of particle groups.
+  ///
+  /// @return
   int getParticleGroupCount() {
     return _particleSystem.getParticleGroupCount();
   }
 
-  /**
-   * Get the number of particles.
-   *
-   * @return
-   */
+  /// Get the number of particles.
+  ///
+  /// @return
   int getParticleCount() {
     return _particleSystem.getParticleCount();
   }
 
-  /**
-   * Get the maximum number of particles.
-   *
-   * @return
-   */
+  /// Get the maximum number of particles.
+  ///
+  /// @return
   int getParticleMaxCount() {
     return _particleSystem.getParticleMaxCount();
   }
 
-  /**
-   * Set the maximum number of particles.
-   *
-   * @param count
-   */
+  /// Set the maximum number of particles.
+  ///
+  /// @param count
   void setParticleMaxCount(int count) {
     _particleSystem.setParticleMaxCount(count);
   }
 
-  /**
-   * Change the particle density.
-   *
-   * @param density
-   */
+  /// Change the particle density.
+  ///
+  /// @param density
   void setParticleDensity(double density) {
     _particleSystem.setParticleDensity(density);
   }
 
-  /**
-   * Get the particle density.
-   *
-   * @return
-   */
+  /// Get the particle density.
+  ///
+  /// @return
   double getParticleDensity() {
     return _particleSystem.getParticleDensity();
   }
 
-  /**
-   * Change the particle gravity scale. Adjusts the effect of the global gravity vector on
-   * particles. Default value is 1.0.
-   *
-   * @param gravityScale
-   */
+  /// Change the particle gravity scale. Adjusts the effect of the global gravity vector on
+  /// particles. Default value is 1.0.
+  ///
+  /// @param gravityScale
   void setParticleGravityScale(double gravityScale) {
     _particleSystem.setParticleGravityScale(gravityScale);
   }
 
-  /**
-   * Get the particle gravity scale.
-   *
-   * @return
-   */
+  /// Get the particle gravity scale.
+  ///
+  /// @return
   double getParticleGravityScale() {
     return _particleSystem.getParticleGravityScale();
   }
 
-  /**
-   * Damping is used to reduce the velocity of particles. The damping parameter can be larger than
-   * 1.0 but the damping effect becomes sensitive to the time step when the damping parameter is
-   * large.
-   *
-   * @param damping
-   */
+  /// Damping is used to reduce the velocity of particles. The damping parameter can be larger than
+  /// 1.0 but the damping effect becomes sensitive to the time step when the damping parameter is
+  /// large.
+  ///
+  /// @param damping
   void setParticleDamping(double damping) {
     _particleSystem.setParticleDamping(damping);
   }
 
-  /**
-   * Get damping for particles
-   *
-   * @return
-   */
+  /// Get damping for particles
+  ///
+  /// @return
   double getParticleDamping() {
     return _particleSystem.getParticleDamping();
   }
 
-  /**
-   * Change the particle radius. You should set this only once, on world start. If you change the
-   * radius during execution, existing particles may explode, shrink, or behave unexpectedly.
-   *
-   * @param radius
-   */
+  /// Change the particle radius. You should set this only once, on world start. If you change the
+  /// radius during execution, existing particles may explode, shrink, or behave unexpectedly.
+  ///
+  /// @param radius
   void setParticleRadius(double radius) {
     _particleSystem.setParticleRadius(radius);
   }
 
-  /**
-   * Get the particle radius.
-   *
-   * @return
-   */
+  /// Get the particle radius.
+  ///
+  /// @return
   double getParticleRadius() {
     return _particleSystem.getParticleRadius();
   }
 
-  /**
-   * Get the particle data. @return the pointer to the head of the particle data.
-   *
-   * @return
-   */
+  /// Get the particle data. @return the pointer to the head of the particle data.
+  ///
+  /// @return
   List<int> getParticleFlagsBuffer() {
     return _particleSystem.getParticleFlagsBuffer();
   }
@@ -1840,12 +1707,10 @@ class World {
     return _particleSystem.getParticleUserDataBuffer();
   }
 
-  /**
-   * Set a buffer for particle data.
-   *
-   * @param buffer is a pointer to a block of memory.
-   * @param size is the number of values in the block.
-   */
+  /// Set a buffer for particle data.
+  ///
+  /// @param buffer is a pointer to a block of memory.
+  /// @param size is the number of values in the block.
   void setParticleFlagsBuffer(List<int> buffer, int capacity) {
     _particleSystem.setParticleFlagsBuffer(buffer, capacity);
   }
@@ -1866,11 +1731,9 @@ class World {
     _particleSystem.setParticleUserDataBuffer(buffer, capacity);
   }
 
-  /**
-   * Get contacts between particles
-   *
-   * @return
-   */
+  /// Get contacts between particles
+  ///
+  /// @return
   List<ParticleContact> getParticleContacts() {
     return _particleSystem.contactBuffer;
   }
@@ -1879,11 +1742,9 @@ class World {
     return _particleSystem.contactCount;
   }
 
-  /**
-   * Get contacts between particles and bodies
-   *
-   * @return
-   */
+  /// Get contacts between particles and bodies
+  ///
+  /// @return
   List<ParticleBodyContact> getParticleBodyContacts() {
     return _particleSystem.bodyContactBuffer;
   }
@@ -1892,11 +1753,9 @@ class World {
     return _particleSystem.bodyContactCount;
   }
 
-  /**
-   * Compute the kinetic energy that can be lost by damping force
-   *
-   * @return
-   */
+  /// Compute the kinetic energy that can be lost by damping force
+  ///
+  /// @return
   double computeParticleCollisionEnergy() {
     return _particleSystem.computeParticleCollisionEnergy();
   }

--- a/lib/src/math_utils.dart
+++ b/lib/src/math_utils.dart
@@ -28,7 +28,7 @@ import 'dart:math' as Math;
 
 import 'vector_math.dart';
 
-const double TWOPI = Math.PI * 2.0;
+const double TWOPI = Math.pi * 2.0;
 
 double distanceSquared(Vector2 v1, Vector2 v2) => v1.distanceToSquared(v2);
 

--- a/lib/src/math_utils.dart
+++ b/lib/src/math_utils.dart
@@ -39,7 +39,7 @@ double clampDouble(final double a, final double low, final double high) =>
     Math.max(low, Math.min(a, high));
 
 Vector2 clampVec2(final Vector2 a, final Vector2 low, final Vector2 high) {
-  final Vector2 min = new Vector2.zero();
+  final Vector2 min = Vector2.zero();
   min.x = a.x < high.x ? a.x : high.x;
   min.y = a.y < high.y ? a.y : high.y;
   min.x = low.x > min.x ? low.x : min.x;
@@ -68,7 +68,7 @@ bool approxEquals(num expected, num actual, [num tolerance = null]) {
 }
 
 Vector2 crossDblVec2(double s, Vector2 a) {
-  return new Vector2(-s * a.y, s * a.x);
+  return Vector2(-s * a.y, s * a.x);
 }
 
 bool vector2Equals(Vector2 a, Vector2 b) {

--- a/lib/src/math_utils.dart
+++ b/lib/src/math_utils.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library box2d.math_utils;
 
@@ -34,7 +34,7 @@ double distanceSquared(Vector2 v1, Vector2 v2) => v1.distanceToSquared(v2);
 
 double distance(Vector2 v1, Vector2 v2) => v1.distanceTo(v2);
 
-/** Returns the closest value to 'a' that is in between 'low' and 'high' */
+/// Returns the closest value to 'a' that is in between 'low' and 'high'
 double clampDouble(final double a, final double low, final double high) =>
     Math.max(low, Math.min(a, high));
 
@@ -47,12 +47,10 @@ Vector2 clampVec2(final Vector2 a, final Vector2 low, final Vector2 high) {
   return min;
 }
 
-/**
- * Given a value within the range specified by [fromMin] and [fromMax],
- * returns a value with the same relative position in the range specified
- * from [toMin] and [toMax]. For example, given a [val] of 2 in the
- * "from range" of 0-4, and a "to range" of 10-20, would return 15.
- */
+/// Given a value within the range specified by [fromMin] and [fromMax],
+/// returns a value with the same relative position in the range specified
+/// from [toMin] and [toMax]. For example, given a [val] of 2 in the
+/// "from range" of 0-4, and a "to range" of 10-20, would return 15.
 double translateAndScale(
     double val, double fromMin, double fromMax, double toMin, double toMax) {
   final double mult = (val - fromMin) / (fromMax - fromMin);

--- a/lib/src/particle/particle_body_contact.dart
+++ b/lib/src/particle/particle_body_contact.dart
@@ -25,14 +25,18 @@
 part of box2d;
 
 class ParticleBodyContact {
-  /** Index of the particle making contact. */
+  /// Index of the particle making contact.
   int index = 0;
-  /** The body making contact. */
+
+  /// The body making contact.
   Body body;
-  /** Weight of the contact. A value between 0.0f and 1.0f. */
+
+  /// Weight of the contact. A value between 0.0f and 1.0f.
   double weight = 0.0;
-  /** The normalized direction from the particle to the body. */
+
+  /// The normalized direction from the particle to the body.
   final Vector2 normal = new Vector2.zero();
-  /** The effective mass used in calculating force. */
+
+  /// The effective mass used in calculating force.
   double mass = 0.0;
 }

--- a/lib/src/particle/particle_color.dart
+++ b/lib/src/particle/particle_color.dart
@@ -30,7 +30,7 @@ part of box2d;
  * @author dmurph
  */
 class ParticleColor {
-  Int8List _data = new Int8List(4);
+  Int8List _data = Int8List(4);
 
   void set r(int v) {
     _data[0] = v;

--- a/lib/src/particle/particle_color.dart
+++ b/lib/src/particle/particle_color.dart
@@ -24,11 +24,7 @@
 
 part of box2d;
 
-/**
- * Small color object for each particle
- * 
- * @author dmurph
- */
+/// Small color object for each particle
 class ParticleColor {
   Int8List _data = Int8List(4);
 

--- a/lib/src/particle/particle_contact.dart
+++ b/lib/src/particle/particle_contact.dart
@@ -25,13 +25,16 @@
 part of box2d;
 
 class ParticleContact {
-  /** Indices of the respective particles making contact. */
+  /// Indices of the respective particles making contact.
   int indexA = 0;
   int indexB = 0;
-  /** The logical sum of the particle behaviors that have been set. */
+
+  /// The logical sum of the particle behaviors that have been set.
   int flags = 0;
-  /** Weight of the contact. A value between 0.0f and 1.0f. */
+
+  /// Weight of the contact. A value between 0.0f and 1.0f.
   double weight = 0.0;
-  /** The normalized direction from A to B. */
+
+  /// The normalized direction from A to B.
   final Vector2 normal = new Vector2.zero();
 }

--- a/lib/src/particle/particle_def.dart
+++ b/lib/src/particle/particle_def.dart
@@ -25,22 +25,20 @@
 part of box2d;
 
 class ParticleDef {
-  /**
-   * Specifies the type of particle. A particle may be more than one type. Multiple types are
-   * chained by logical sums, for example: pd.flags = ParticleType.b2_elasticParticle |
-   * ParticleType.b2_viscousParticle.
-   */
+  /// Specifies the type of particle. A particle may be more than one type. Multiple types are
+  /// chained by logical sums, for example: pd.flags = ParticleType.b2_elasticParticle |
+  /// ParticleType.b2_viscousParticle.
   int flags = 0;
 
-  /** The world position of the particle. */
+  /// The world position of the particle.
   final Vector2 position = new Vector2.zero();
 
-  /** The linear velocity of the particle in world co-ordinates. */
+  /// The linear velocity of the particle in world co-ordinates.
   final Vector2 velocity = new Vector2.zero();
 
-  /** The color of the particle. */
+  /// The color of the particle.
   ParticleColor color;
 
-  /** Use this to store application-specific body data. */
+  /// Use this to store application-specific body data.
   Object userData;
 }

--- a/lib/src/particle/particle_group_def.dart
+++ b/lib/src/particle/particle_group_def.dart
@@ -24,50 +24,42 @@
 
 part of box2d;
 
-/**
- * A particle group definition holds all the data needed to construct a particle group. You can
- * safely re-use these definitions.
- */
+/// A particle group definition holds all the data needed to construct a particle group. You can
+/// safely re-use these definitions.
 class ParticleGroupDef {
-  /** The particle-behavior flags. */
+  /// The particle-behavior flags.
   int flags = 0;
 
-  /** The group-construction flags. */
+  /// The group-construction flags.
   int groupFlags = 0;
 
-  /**
-   * The world position of the group. Moves the group's shape a distance equal to the value of
-   * position.
-   */
+  /// The world position of the group. Moves the group's shape a distance equal to the value of
+  /// position.
   final Vector2 position = new Vector2.zero();
 
-  /**
-   * The world angle of the group in radians. Rotates the shape by an angle equal to the value of
-   * angle.
-   */
+  /// The world angle of the group in radians. Rotates the shape by an angle equal to the value of
+  /// angle.
   double angle = 0.0;
 
-  /** The linear velocity of the group's origin in world co-ordinates. */
+  /// The linear velocity of the group's origin in world co-ordinates.
   final Vector2 linearVelocity = new Vector2.zero();
 
-  /** The angular velocity of the group. */
+  /// The angular velocity of the group.
   double angularVelocity = 0.0;
 
-  /** The color of all particles in the group. */
+  /// The color of all particles in the group.
   ParticleColor color;
 
-  /**
-   * The strength of cohesion among the particles in a group with flag b2_elasticParticle or
-   * b2_springParticle.
-   */
+  /// The strength of cohesion among the particles in a group with flag b2_elasticParticle or
+  /// b2_springParticle.
   double strength = 1.0;
 
-  /** Shape containing the particle group. */
+  /// Shape containing the particle group.
   Shape shape;
 
-  /** If true, destroy the group automatically after its last particle has been destroyed. */
+  /// If true, destroy the group automatically after its last particle has been destroyed.
   bool destroyAutomatically = true;
 
-  /** Use this to store application-specific group data. */
+  /// Use this to store application-specific group data.
   Object userData;
 }

--- a/lib/src/particle/particle_group_type.dart
+++ b/lib/src/particle/particle_group_type.dart
@@ -25,8 +25,9 @@
 part of box2d;
 
 class ParticleGroupType {
-  /** resists penetration */
+  /// resists penetration
   static const int b2_solidParticleGroup = 1 << 0;
-  /** keeps its shape */
+
+  /// keeps its shape
   static const int b2_rigidParticleGroup = 1 << 1;
 }

--- a/lib/src/particle/particle_system.dart
+++ b/lib/src/particle/particle_system.dart
@@ -947,7 +947,7 @@ class ParticleSystem {
     depthBuffer = requestParticleBufferFloat64(depthBuffer);
     for (int i = group._firstIndex; i < group._lastIndex; i++) {
       double w = accumulationBuffer[i];
-      depthBuffer[i] = w < 0.8 ? 0.0 : double.MAX_FINITE;
+      depthBuffer[i] = w < 0.8 ? 0.0 : double.maxFinite;
     }
     int interationCount = group.getParticleCount();
     for (int t = 0; t < interationCount; t++) {
@@ -981,7 +981,7 @@ class ParticleSystem {
     }
     for (int i = group._firstIndex; i < group._lastIndex; i++) {
       double p = depthBuffer[i];
-      if (p < double.MAX_FINITE) {
+      if (p < double.maxFinite) {
         depthBuffer[i] *= particleDiameter;
       } else {
         depthBuffer[i] = 0.0;
@@ -1009,7 +1009,7 @@ class ParticleSystem {
             contactBuffer, oldCapacity, newCapacity, allocParticleContact);
         contactCapacity = newCapacity;
       }
-      double invD = d2 != 0 ? Math.sqrt(1 / d2) : double.MAX_FINITE;
+      double invD = d2 != 0 ? Math.sqrt(1 / d2) : double.maxFinite;
       ParticleContact contact = contactBuffer[contactCount];
       contact.indexA = a;
       contact.indexB = b;
@@ -1078,10 +1078,10 @@ class ParticleSystem {
 
   void updateBodyContacts() {
     final AABB aabb = _temp;
-    aabb.lowerBound.x = double.MAX_FINITE;
-    aabb.lowerBound.y = double.MAX_FINITE;
-    aabb.upperBound.x = -double.MAX_FINITE;
-    aabb.upperBound.y = -double.MAX_FINITE;
+    aabb.lowerBound.x = double.maxFinite;
+    aabb.lowerBound.y = double.maxFinite;
+    aabb.upperBound.x = -double.maxFinite;
+    aabb.upperBound.y = -double.maxFinite;
     for (int i = 0; i < count; i++) {
       Vector2 p = positionBuffer.data[i];
       Vector2.min(aabb.lowerBound, p, aabb.lowerBound);
@@ -1103,10 +1103,10 @@ class ParticleSystem {
     final AABB aabb = _temp;
     final Vector2 lowerBound = aabb.lowerBound;
     final Vector2 upperBound = aabb.upperBound;
-    lowerBound.x = double.MAX_FINITE;
-    lowerBound.y = double.MAX_FINITE;
-    upperBound.x = -double.MAX_FINITE;
-    upperBound.y = -double.MAX_FINITE;
+    lowerBound.x = double.maxFinite;
+    lowerBound.y = double.maxFinite;
+    upperBound.x = -double.maxFinite;
+    upperBound.y = -double.maxFinite;
     for (int i = 0; i < count; i++) {
       final Vector2 v = velocityBuffer.data[i];
       final Vector2 p1 = positionBuffer.data[i];
@@ -1159,7 +1159,7 @@ class ParticleSystem {
       double v2 = v.x * v.x + v.y * v.y;
       if (v2 > criticalVelocytySquared) {
         double a = v2 == 0
-            ? double.MAX_FINITE
+            ? double.maxFinite
             : Math.sqrt(criticalVelocytySquared / v2);
         v.x *= a;
         v.y *= a;
@@ -1402,7 +1402,7 @@ class ParticleSystem {
         double rs = oa.cross(pa) + ob.cross(pb) + oc.cross(pc);
         double rc = oa.dot(pa) + ob.dot(pb) + oc.dot(pc);
         double r2 = rs * rs + rc * rc;
-        double invR = r2 == 0 ? double.MAX_FINITE : Math.sqrt(1.0 / r2);
+        double invR = r2 == 0 ? double.maxFinite : Math.sqrt(1.0 / r2);
         rs *= invR;
         rc *= invR;
         final double strength = elasticStrength_ * triad.strength;
@@ -1438,7 +1438,7 @@ class ParticleSystem {
         final double dy = pb.y - pa.y;
         double r0 = pair.distance;
         double r1 = Math.sqrt(dx * dx + dy * dy);
-        if (r1 == 0) r1 = double.MAX_FINITE;
+        if (r1 == 0) r1 = double.maxFinite;
         double strength = springStrength_ * pair.strength;
         final double fx = strength * (r0 - r1) / r1 * dx;
         final double fy = strength * (r0 - r1) / r1 * dy;
@@ -2158,7 +2158,7 @@ class ParticleSystem {
     final double vx = point2.x - point1.x;
     final double vy = point2.y - point1.y;
     double v2 = vx * vx + vy * vy;
-    if (v2 == 0) v2 = double.MAX_FINITE;
+    if (v2 == 0) v2 = double.maxFinite;
     for (int proxy = firstProxy; proxy < lastProxy; ++proxy) {
       int i = proxyBuffer[proxy].index;
       final Vector2 posI = positionBuffer.data[i];

--- a/lib/src/particle/particle_system.dart
+++ b/lib/src/particle/particle_system.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 part of box2d;
 
@@ -38,7 +38,7 @@ class ParticleBufferInt {
   int userSuppliedCapacity;
 }
 
-/** Connection between two particles */
+/// Connection between two particles
 class PsPair {
   int indexA = 0;
   int indexB = 0;
@@ -47,7 +47,7 @@ class PsPair {
   double distance = 0.0;
 }
 
-/** Connection between three particles */
+/// Connection between three particles
 class PsTriad {
   int indexA = 0, indexB = 0, indexC = 0;
   int flags = 0;
@@ -56,7 +56,7 @@ class PsTriad {
   double ka = 0.0, kb = 0.0, kc = 0.0, s = 0.0;
 }
 
-/** Used for detecting particle contacts */
+/// Used for detecting particle contacts
 class PsProxy implements Comparable<PsProxy> {
   int index = 0;
   int tag = 0;
@@ -434,11 +434,13 @@ class ParticleSystemTest {
 }
 
 class ParticleSystem {
-  /** All particle types that require creating pairs */
+  /// All particle types that require creating pairs
   static const int k_pairFlags = ParticleType.b2_springParticle;
-  /** All particle types that require creating triads */
+
+  /// All particle types that require creating triads
   static const int k_triadFlags = ParticleType.b2_elasticParticle;
-  /** All particle types that require computing depth */
+
+  /// All particle types that require computing depth
   static const int k_noPressureFlags = ParticleType.b2_powderParticle;
 
   static const int xTruncBits = 12;
@@ -2129,11 +2131,9 @@ class ParticleSystem {
     }
   }
 
-  /**
-   * @param callback
-   * @param point1
-   * @param point2
-   */
+  /// @param callback
+  /// @param point1
+  /// @param point2
   void raycast(ParticleRaycastCallback callback, final Vector2 point1,
       final Vector2 point2) {
     if (proxyCount == 0) {

--- a/lib/src/particle/particle_system.dart
+++ b/lib/src/particle/particle_system.dart
@@ -52,9 +52,9 @@ class PsTriad {
   int indexA = 0, indexB = 0, indexC = 0;
   int flags = 0;
   double strength = 0.0;
-  final Vector2 pa = new Vector2.zero(),
-      pb = new Vector2.zero(),
-      pc = new Vector2.zero();
+  final Vector2 pa = Vector2.zero(),
+      pb = Vector2.zero(),
+      pc = Vector2.zero();
   double ka = 0.0, kb = 0.0, kc = 0.0, s = 0.0;
 }
 
@@ -126,10 +126,10 @@ class DestroyParticlesInShapeCallback implements ParticleQueryCallback {
 class UpdateBodyContactsCallback implements QueryCallback {
   ParticleSystem system;
 
-  final Vector2 _tempVec = new Vector2.zero();
+  final Vector2 _tempVec = Vector2.zero();
 
   static ParticleBodyContact allocParticleBodyContact() =>
-      new ParticleBodyContact();
+      ParticleBodyContact();
 
   bool reportFixture(Fixture fixture) {
     if (fixture.isSensor()) {
@@ -211,7 +211,7 @@ class UpdateBodyContactsCallback implements QueryCallback {
   }
 }
 
-PsTriad allocPsTriad() => new PsTriad();
+PsTriad allocPsTriad() => PsTriad();
 
 // Callback used with VoronoiDiagram.
 class CreateParticleGroupCallback implements VoronoiDiagramCallback {
@@ -336,10 +336,10 @@ class SolveCollisionCallback implements QueryCallback {
   ParticleSystem system;
   TimeStep step;
 
-  final RayCastInput input = new RayCastInput();
-  final RayCastOutput output = new RayCastOutput();
-  final Vector2 tempVec = new Vector2.zero();
-  final Vector2 tempVec2 = new Vector2.zero();
+  final RayCastInput input = RayCastInput();
+  final RayCastOutput output = RayCastOutput();
+  final Vector2 tempVec = Vector2.zero();
+  final Vector2 tempVec2 = Vector2.zero();
 
   bool reportFixture(Fixture fixture) {
     if (fixture.isSensor()) {
@@ -527,11 +527,11 @@ class ParticleSystem {
 
   World world;
 
-  static Vector2 allocVec2() => new Vector2.zero();
-  static Object allocObject() => new Object();
-  static ParticleColor allocParticleColor() => new ParticleColor();
-  static ParticleGroup allocParticleGroup() => new ParticleGroup();
-  static PsProxy allocPsProxy() => new PsProxy();
+  static Vector2 allocVec2() => Vector2.zero();
+  static Object allocObject() => Object();
+  static ParticleColor allocParticleColor() => ParticleColor();
+  static ParticleGroup allocParticleGroup() => ParticleGroup();
+  static PsProxy allocPsProxy() => PsProxy();
 
   ParticleSystem(World world) {
     world = world;
@@ -547,11 +547,11 @@ class ParticleSystem {
     ejectionStrength = 0.5;
     colorMixingStrength = 0.5;
 
-    flagsBuffer = new ParticleBufferInt();
-    positionBuffer = new ParticleBuffer<Vector2>(allocVec2);
-    velocityBuffer = new ParticleBuffer<Vector2>(allocVec2);
-    colorBuffer = new ParticleBuffer<ParticleColor>(allocParticleColor);
-    userDataBuffer = new ParticleBuffer<Object>(allocObject);
+    flagsBuffer = ParticleBufferInt();
+    positionBuffer = ParticleBuffer<Vector2>(allocVec2);
+    velocityBuffer = ParticleBuffer<Vector2>(allocVec2);
+    colorBuffer = ParticleBuffer<ParticleColor>(allocParticleColor);
+    userDataBuffer = ParticleBuffer<Object>(allocObject);
   }
 
   int createParticle(ParticleDef def) {
@@ -647,7 +647,7 @@ class ParticleSystem {
 
   List<T> requestParticleBuffer<T>(List<T> buffer, T allocClosure()) {
     if (buffer == null) {
-      buffer = new List<T>(internalAllocatedCapacity);
+      buffer = List<T>(internalAllocatedCapacity);
       for (int i = 0; i < internalAllocatedCapacity; i++) {
         try {
           buffer[i] = allocClosure();
@@ -661,7 +661,7 @@ class ParticleSystem {
 
   Float64List requestParticleBufferFloat64(Float64List buffer) {
     if (buffer == null) {
-      buffer = new Float64List(internalAllocatedCapacity);
+      buffer = Float64List(internalAllocatedCapacity);
     }
     return buffer;
   }
@@ -674,9 +674,9 @@ class ParticleSystem {
     flagsBuffer.data[index] |= flags;
   }
 
-  final AABB _temp = new AABB();
+  final AABB _temp = AABB();
   final DestroyParticlesInShapeCallback _dpcallback =
-      new DestroyParticlesInShapeCallback();
+      DestroyParticlesInShapeCallback();
 
   int destroyParticlesInShape(
       Shape shape, Transform xf, bool callDestructionListener) {
@@ -693,13 +693,13 @@ class ParticleSystem {
     }
   }
 
-  final AABB _temp2 = new AABB();
-  final Vector2 _tempVec = new Vector2.zero();
-  final Transform _tempTransform = new Transform.zero();
-  final Transform _tempTransform2 = new Transform.zero();
+  final AABB _temp2 = AABB();
+  final Vector2 _tempVec = Vector2.zero();
+  final Transform _tempTransform = Transform.zero();
+  final Transform _tempTransform2 = Transform.zero();
   CreateParticleGroupCallback _createParticleGroupCallback =
-      new CreateParticleGroupCallback();
-  final ParticleDef _tempParticleDef = new ParticleDef();
+      CreateParticleGroupCallback();
+  final ParticleDef _tempParticleDef = ParticleDef();
 
   ParticleGroup createParticleGroup(ParticleGroupDef groupDef) {
     double stride = getParticleStride();
@@ -752,7 +752,7 @@ class ParticleSystem {
     }
     int lastIndex = count;
 
-    ParticleGroup group = new ParticleGroup();
+    ParticleGroup group = ParticleGroup();
     group._system = this;
     group._firstIndex = firstIndex;
     group._lastIndex = lastIndex;
@@ -805,7 +805,7 @@ class ParticleSystem {
       }
     }
     if ((groupDef.flags & k_triadFlags) != 0) {
-      VoronoiDiagram diagram = new VoronoiDiagram(lastIndex - firstIndex);
+      VoronoiDiagram diagram = VoronoiDiagram(lastIndex - firstIndex);
       for (int i = firstIndex; i < lastIndex; i++) {
         diagram.addGenerator(positionBuffer.data[i], i);
       }
@@ -822,7 +822,7 @@ class ParticleSystem {
     return group;
   }
 
-  static PsPair allocPsPair() => new PsPair();
+  static PsPair allocPsPair() => PsPair();
 
   void joinParticleGroups(ParticleGroup groupA, ParticleGroup groupB) {
     assert(groupA != groupB);
@@ -873,14 +873,14 @@ class ParticleSystem {
     }
     if ((particleFlags & k_triadFlags) != 0) {
       VoronoiDiagram diagram =
-          new VoronoiDiagram(groupB._lastIndex - groupA._firstIndex);
+          VoronoiDiagram(groupB._lastIndex - groupA._firstIndex);
       for (int i = groupA._firstIndex; i < groupB._lastIndex; i++) {
         if ((flagsBuffer.data[i] & ParticleType.b2_zombieParticle) == 0) {
           diagram.addGenerator(positionBuffer.data[i], i);
         }
       }
       diagram.generate(getParticleStride() / 2);
-      JoinParticleGroupsCallback callback = new JoinParticleGroupsCallback();
+      JoinParticleGroupsCallback callback = JoinParticleGroupsCallback();
       callback.system = this;
       callback.groupA = groupA;
       callback.groupB = groupB;

--- a/lib/src/particle/particle_system.dart
+++ b/lib/src/particle/particle_system.dart
@@ -52,9 +52,7 @@ class PsTriad {
   int indexA = 0, indexB = 0, indexC = 0;
   int flags = 0;
   double strength = 0.0;
-  final Vector2 pa = Vector2.zero(),
-      pb = Vector2.zero(),
-      pc = Vector2.zero();
+  final Vector2 pa = Vector2.zero(), pb = Vector2.zero(), pc = Vector2.zero();
   double ka = 0.0, kb = 0.0, kc = 0.0, s = 0.0;
 }
 

--- a/lib/src/particle/particle_type.dart
+++ b/lib/src/particle/particle_type.dart
@@ -24,29 +24,34 @@
 
 part of box2d;
 
-/**
- * The particle type. Can be combined with | operator. Zero means liquid.
- * 
- * @author dmurph
- */
+/// The particle type. Can be combined with | operator. Zero means liquid.
 class ParticleType {
   static const int b2_waterParticle = 0;
-  /** removed after next step */
+
+  /// removed after next step
   static const int b2_zombieParticle = 1 << 1;
-  /** zero velocity */
+
+  /// zero velocity
   static const int b2_wallParticle = 1 << 2;
-  /** with restitution from stretching */
+
+  /// with restitution from stretching
   static const int b2_springParticle = 1 << 3;
-  /** with restitution from deformation */
+
+  /// with restitution from deformation
   static const int b2_elasticParticle = 1 << 4;
-  /** with viscosity */
+
+  /// with viscosity
   static const int b2_viscousParticle = 1 << 5;
-  /** without isotropic pressure */
+
+  /// without isotropic pressure
   static const int b2_powderParticle = 1 << 6;
-  /** with surface tension */
+
+  /// with surface tension
   static const int b2_tensileParticle = 1 << 7;
-  /** mixing color between contacting particles */
+
+  /// mixing color between contacting particles
   static const int b2_colorMixingParticle = 1 << 8;
-  /** call b2DestructionListener on destruction */
+
+  /// call b2DestructionListener on destruction
   static const int b2_destructionListener = 1 << 9;
 }

--- a/lib/src/particle/voronoi_diagram.dart
+++ b/lib/src/particle/voronoi_diagram.dart
@@ -118,10 +118,10 @@ class VoronoiDiagram {
   void generate(double radius) {
     assert(_diagram == null);
     double inverseRadius = 1 / radius;
-    _lower.x = double.MAX_FINITE;
-    _lower.y = double.MAX_FINITE;
-    _upper.x = -double.MAX_FINITE;
-    _upper.y = -double.MAX_FINITE;
+    _lower.x = double.maxFinite;
+    _lower.y = double.maxFinite;
+    _upper.x = -double.maxFinite;
+    _upper.y = -double.maxFinite;
     for (int k = 0; k < _generatorCount; k++) {
       VoronoiGenerator g = _generatorBuffer[k];
       Vector2.min(_lower, g.center, _lower);

--- a/lib/src/pooling/idynamic_stack.dart
+++ b/lib/src/pooling/idynamic_stack.dart
@@ -25,15 +25,11 @@
 part of box2d;
 
 abstract class IDynamicStack<E> {
-  /**
-   * Pops an item off the stack
-   * @return
-   */
+  /// Pops an item off the stack
+  /// @return
   E pop();
 
-  /**
-   * Pushes an item back on the stack
-   * @param argObject
-   */
+  /// Pushes an item back on the stack
+  /// @param argObject
   void push(E argObject);
 }

--- a/lib/src/pooling/iordered_stack.dart
+++ b/lib/src/pooling/iordered_stack.dart
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * Copyright (c) 2015, Daniel Murphy, Google
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *  * Redistributions of source code must retain the above copyright notice,
@@ -9,7 +9,7 @@
  *  * Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -25,25 +25,17 @@
 part of box2d;
 
 abstract class IOrderedStack<E> {
-  /**
-   * Returns the next object in the pool
-   * @return
-   */
+  /// Returns the next object in the pool
   E pop();
 
-  /**
-   * Returns the next 'argNum' objects in the pool
-   * in an array
-   * @param argNum
-   * @return an array containing the next pool objects in
-   *       items 0-argNum.  Array length and uniqueness not
-   *       guaranteed.
-   */
+  /// Returns the next 'argNum' objects in the pool
+  /// in an array
+  /// @param argNum
+  /// @return an array containing the next pool objects in
+  ///       items 0-argNum.  Array length and uniqueness not
+  ///       guaranteed.
   List<E> popSome(int argNum);
 
-  /**
-   * Tells the stack to take back the last 'argNum' items
-   * @param argNum
-   */
+  /// Tells the stack to take back the last 'argNum' items
   void push(int argNum);
 }

--- a/lib/src/pooling/normal/default_world_pool.dart
+++ b/lib/src/pooling/normal/default_world_pool.dart
@@ -24,10 +24,8 @@
 
 part of box2d;
 
-/**
- * Provides object pooling for all objects used in the engine. Objects retrieved from here should
- * only be used temporarily, and then pushed back (with the exception of arrays).
- */
+/// Provides object pooling for all objects used in the engine. Objects retrieved from here should
+/// only be used temporarily, and then pushed back (with the exception of arrays).
 
 class OrderedStackVec2 extends OrderedStack<Vector2> {
   OrderedStackVec2(int argStackSize, int argContainerSize)

--- a/lib/src/pooling/normal/mutable_stack.dart
+++ b/lib/src/pooling/normal/mutable_stack.dart
@@ -61,7 +61,7 @@ abstract class MutableStack<E> implements IDynamicStack<E> {
     _stack[--_index] = argObject;
   }
 
-  /** Creates a new instance of the object contained by this stack. */
+  /// Creates a new instance of the object contained by this stack.
   E newInstance();
 
   List<E> newArray(int size) {

--- a/lib/src/pooling/normal/ordered_stack.dart
+++ b/lib/src/pooling/normal/ordered_stack.dart
@@ -61,6 +61,6 @@ abstract class OrderedStack<E> {
     assert(_index >= 0);
   }
 
-  /** Creates a new instance of the object contained by this stack. */
+  /// Creates a new instance of the object contained by this stack.
   E newInstance();
 }

--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -65,7 +65,7 @@ const double linearSlop = 0.005;
  * A small angle used as a collision and constraint tolerance. Usually it is chosen to be
  * numerically significant, but visually insignificant.
  */
-const double angularSlop = (2.0 / 180.0 * Math.PI);
+const double angularSlop = (2.0 / 180.0 * Math.pi);
 
 /**
  * The radius of the polygon/edge shape skin. This should not be modified. Making this smaller
@@ -100,7 +100,7 @@ const double maxLinearCorrection = 0.2;
  * The maximum angular position correction used when solving constraints. This helps to prevent
  * overshoot.
  */
-const double maxAngularCorrection = (8.0 / 180.0 * Math.PI);
+const double maxAngularCorrection = (8.0 / 180.0 * Math.pi);
 
 /**
  * The maximum linear velocity of a body. This limit is very large and is used to prevent
@@ -113,7 +113,7 @@ const double maxTranslationSquared = (maxTranslation * maxTranslation);
  * The maximum angular velocity of a body. This limit is very large and is used to prevent
  * numerical problems. You shouldn't need to adjust this.
  */
-const double maxRotation = (0.5 * Math.PI);
+const double maxRotation = (0.5 * Math.pi);
 const double maxRotationSquared = (maxRotation * maxRotation);
 
 /**
@@ -138,7 +138,7 @@ const double linearSleepTolerance = 0.01;
 /**
  * A body cannot sleep if its angular velocity is above this tolerance.
  */
-const double angularSleepTolerance = (2.0 / 180.0 * Math.PI);
+const double angularSleepTolerance = (2.0 / 180.0 * Math.pi);
 
 // Particle
 

--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -1,26 +1,26 @@
-/*******************************************************************************
- * Copyright (c) 2015, Daniel Murphy, Google
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *  * Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
- * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
+/// *****************************************************************************
+/// Copyright (c) 2015, Daniel Murphy, Google
+/// All rights reserved.
+///
+/// Redistribution and use in source and binary forms, with or without modification,
+/// are permitted provided that the following conditions are met:
+///  * Redistributions of source code must retain the above copyright notice,
+///    this list of conditions and the following disclaimer.
+///  * Redistributions in binary form must reproduce the above copyright notice,
+///    this list of conditions and the following disclaimer in the documentation
+///    and/or other materials provided with the distribution.
+///
+/// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+/// IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+/// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+/// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+/// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+/// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+/// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+/// POSSIBILITY OF SUCH DAMAGE.
+/// *****************************************************************************
 
 library box2d.settings;
 
@@ -28,147 +28,101 @@ import 'dart:math' as Math;
 
 const int INTEGER_MAX_VALUE = 0x3FFFFFFF;
 
-/** A "close to zero" float epsilon value for use */
+/// A "close to zero" float epsilon value for use
 const double EPSILON = 1.1920928955078125E-7;
 
 const int CONTACT_STACK_INIT_SIZE = 10;
 
-/**
- * The maximum number of contact points between two convex shapes.
- */
+/// The maximum number of contact points between two convex shapes.
 const int maxManifoldPoints = 2;
 
-/**
- * The maximum number of vertices on a convex polygon.
- */
+/// The maximum number of vertices on a convex polygon.
 const int maxPolygonVertices = 8;
 
-/**
- * This is used to fatten AABBs in the dynamic tree. This allows proxies to move by a small amount
- * without triggering a tree adjustment. This is in meters.
- */
+/// This is used to fatten AABBs in the dynamic tree. This allows proxies to move by a small amount
+/// without triggering a tree adjustment. This is in meters.
 const double aabbExtension = 0.1;
 
-/**
- * This is used to fatten AABBs in the dynamic tree. This is used to predict the future position
- * based on the current displacement. This is a dimensionless multiplier.
- */
+/// This is used to fatten AABBs in the dynamic tree. This is used to predict the future position
+/// based on the current displacement. This is a dimensionless multiplier.
 const double aabbMultiplier = 2.0;
 
-/**
- * A small length used as a collision and constraint tolerance. Usually it is chosen to be
- * numerically significant, but visually insignificant.
- */
+/// A small length used as a collision and constraint tolerance. Usually it is chosen to be
+/// numerically significant, but visually insignificant.
 const double linearSlop = 0.005;
 
-/**
- * A small angle used as a collision and constraint tolerance. Usually it is chosen to be
- * numerically significant, but visually insignificant.
- */
+/// A small angle used as a collision and constraint tolerance. Usually it is chosen to be
+/// numerically significant, but visually insignificant.
 const double angularSlop = (2.0 / 180.0 * Math.pi);
 
-/**
- * The radius of the polygon/edge shape skin. This should not be modified. Making this smaller
- * means polygons will have and insufficient for continuous collision. Making it larger may create
- * artifacts for vertex collision.
- */
+/// The radius of the polygon/edge shape skin. This should not be modified. Making this smaller
+/// means polygons will have and insufficient for continuous collision. Making it larger may create
+/// artifacts for vertex collision.
 const double polygonRadius = (2.0 * linearSlop);
 
-/** Maximum number of sub-steps per contact in continuous physics simulation. */
+/// Maximum number of sub-steps per contact in continuous physics simulation.
 const int maxSubSteps = 8;
 
 // Dynamics
 
-/**
-   * Maximum number of contacts to be handled to solve a TOI island.
-   */
+/// Maximum number of contacts to be handled to solve a TOI island.
 const int maxTOIContacts = 32;
 
-/**
- * A velocity threshold for elastic collisions. Any collision with a relative linear velocity
- * below this threshold will be treated as inelastic.
- */
+/// A velocity threshold for elastic collisions. Any collision with a relative linear velocity
+/// below this threshold will be treated as inelastic.
 double velocityThreshold = 1.0;
 
-/**
- * The maximum linear position correction used when solving constraints. This helps to prevent
- * overshoot.
- */
+/// The maximum linear position correction used when solving constraints. This helps to prevent
+/// overshoot.
 const double maxLinearCorrection = 0.2;
 
-/**
- * The maximum angular position correction used when solving constraints. This helps to prevent
- * overshoot.
- */
+/// The maximum angular position correction used when solving constraints. This helps to prevent
+/// overshoot.
 const double maxAngularCorrection = (8.0 / 180.0 * Math.pi);
 
-/**
- * The maximum linear velocity of a body. This limit is very large and is used to prevent
- * numerical problems. You shouldn't need to adjust this.
- */
+/// The maximum linear velocity of a body. This limit is very large and is used to prevent
+/// numerical problems. You shouldn't need to adjust this.
 const double maxTranslation = 2.0;
 const double maxTranslationSquared = (maxTranslation * maxTranslation);
 
-/**
- * The maximum angular velocity of a body. This limit is very large and is used to prevent
- * numerical problems. You shouldn't need to adjust this.
- */
+/// The maximum angular velocity of a body. This limit is very large and is used to prevent
+/// numerical problems. You shouldn't need to adjust this.
 const double maxRotation = (0.5 * Math.pi);
 const double maxRotationSquared = (maxRotation * maxRotation);
 
-/**
- * This scale factor controls how fast overlap is resolved. Ideally this would be 1 so that
- * overlap is removed in one time step. However using values close to 1 often lead to overshoot.
- */
+/// This scale factor controls how fast overlap is resolved. Ideally this would be 1 so that
+/// overlap is removed in one time step. However using values close to 1 often lead to overshoot.
 const double baumgarte = 0.2;
 const double toiBaugarte = 0.75;
 
 // Sleep
 
-/**
- * The time that a body must be still before it will go to sleep.
- */
+/// The time that a body must be still before it will go to sleep.
 const double timeToSleep = 0.5;
 
-/**
- * A body cannot sleep if its linear velocity is above this tolerance.
- */
+/// A body cannot sleep if its linear velocity is above this tolerance.
 const double linearSleepTolerance = 0.01;
 
-/**
- * A body cannot sleep if its angular velocity is above this tolerance.
- */
+/// A body cannot sleep if its angular velocity is above this tolerance.
 const double angularSleepTolerance = (2.0 / 180.0 * Math.pi);
 
 // Particle
 
-/**
- * A symbolic constant that stands for particle allocation error.
- */
+/// A symbolic constant that stands for particle allocation error.
 const int invalidParticleIndex = (-1);
 
-/**
- * The standard distance between particles, divided by the particle radius.
- */
+/// The standard distance between particles, divided by the particle radius.
 const double particleStride = 0.75;
 
-/**
- * The minimum particle weight that produces pressure.
- */
+/// The minimum particle weight that produces pressure.
 const double minParticleWeight = 1.0;
 
-/**
- * The upper limit for particle weight used in pressure calculation.
- */
+/// The upper limit for particle weight used in pressure calculation.
 const double maxParticleWeight = 5.0;
 
-/**
- * The maximum distance between particles in a triad, divided by the particle radius.
- */
+/// The maximum distance between particles in a triad, divided by the particle radius.
 const int maxTriadDistance = 2;
 const int maxTriadDistanceSquared = (maxTriadDistance * maxTriadDistance);
 
-/**
- * The initial size of particle data buffers.
- */
+/// The initial size of particle data buffers.
 const int minParticleBufferCapacity = 256;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,5 @@
 name: box2d_flame
-version: 0.4.4
-authors:
-- Kevin Moore <kevmoo@google.com>
-- Srdjan Mitrovic <srdjan@google.com>
-- Filip Hracek <filiph@google.com>
+version: 0.4.5
 description: A Dart 2D physics engine, port from the Java version, works for Web/Flutter
 homepage: https://github.com/feroult/box2d.dart
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,12 @@
 name: box2d_flame
-version: 0.4.1
+version: 0.4.2
 authors:
 - Kevin Moore <kevmoo@google.com>
 - Srdjan Mitrovic <srdjan@google.com>
 - Filip Hracek <filiph@google.com>
-description: A Dart 2D physics engine
-homepage: https://github.com/google/box2d.dart
+description: A Dart 2D physics engine, port from the Java version, works for Web/Flutter
+homepage: https://github.com/feroult/box2d.dart
 dependencies:
   vector_math: '>=2.0.0 <3.0.0'
-transformers:
-- $dart2js:
-    commandLineOptions:
-    - --trust-type-annotations
-    - --trust-primitives
+environment:
+  sdk: ">=2.0.0-dev.50.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
-name: box2d
-version: 0.4.0
+name: box2d-flame
+version: 0.4.1
 authors:
 - Kevin Moore <kevmoo@google.com>
 - Srdjan Mitrovic <srdjan@google.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,6 @@ description: A Dart 2D physics engine
 homepage: https://github.com/google/box2d.dart
 dependencies:
   vector_math: '>=2.0.0 <3.0.0'
-dev_dependencies:
-  browser: '>=0.10.0 <0.11.0'
 transformers:
 - $dart2js:
     commandLineOptions:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: box2d_flame
-version: 0.4.2
+version: 0.4.3
 authors:
 - Kevin Moore <kevmoo@google.com>
 - Srdjan Mitrovic <srdjan@google.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: box2d-flame
+name: box2d_flame
 version: 0.4.1
 authors:
 - Kevin Moore <kevmoo@google.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: box2d_flame
-version: 0.4.3
+version: 0.4.4
 authors:
 - Kevin Moore <kevmoo@google.com>
 - Srdjan Mitrovic <srdjan@google.com>


### PR DESCRIPTION
Example:

```
Fix lib/src/collision/collision.dart. (-25 points)
Analysis of lib/src/collision/collision.dart reported 88 hints, including:
line 27 col 1: Prefer using /// for doc comments.
line 35 col 1: Prefer using /// for doc comments.
```

This changes all /**/ docs for /// docs

Also removes some commented out code and invalid documentation that I saw while skimming (most of the replaces were done automatically though)